### PR TITLE
Add two more ECDH methods, so we have 3 ECDH methods

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,12 +5,10 @@ import PackageDescription
 
 let package = Package(
     name: "K1",
-    
     platforms: [
       .macOS(.v11),
       .iOS(.v13),
     ],
-
     products: [
         .library(
             name: "K1",
@@ -19,12 +17,10 @@ let package = Package(
             ]
         ),
     ],
-
     dependencies: [
          // Only used by tests
         .package(url: "https://github.com/filom/ASN1Decoder", from: "1.8.0")
     ],
-
     targets: [
         
         // Target `libsecp256k1` https://github.com/bitcoin-core/secp256k1

--- a/Sources/K1/K1/K1/Error.swift
+++ b/Sources/K1/K1/K1/Error.swift
@@ -27,7 +27,7 @@ public extension K1 {
         case incorrectByteCountOfMessageToValidate
         case failedToCompressPublicKey
         case failedToUncompressPublicKey
-        
+        case failedToProduceSharedSecret
         case incorrectByteCountOfPublicKey(got: Int, acceptableLengths: [Int])
         case failedToParsePublicKeyFromBytes
         case failedToParseDERSignature

--- a/Sources/secp256k1/src/ecdh_no_hashfp.c
+++ b/Sources/secp256k1/src/ecdh_no_hashfp.c
@@ -1,5 +1,5 @@
 //
-//  ecdh_no_hashfp.c.c
+//  ecdh_no_hashfp.c
 //  
 //
 //  Created by Alexander Cyon on 2022-01-31.
@@ -14,5 +14,11 @@ int ecdh_skip_hash_extract_x_and_y(unsigned char *output, const unsigned char *x
     output[0] = 0x04;
     memcpy(output + 1, x32, 32);
     memcpy(output + 33, y32, 32);
+    return 1;
+}
+
+int ecdh_skip_hash_extract_only_x(unsigned char *output, const unsigned char *x32, const unsigned char *y32, void *data) {
+    (void)data;
+    memcpy(output, x32, 32);
     return 1;
 }

--- a/Sources/secp256k1/src/ecdh_no_hashfp.h
+++ b/Sources/secp256k1/src/ecdh_no_hashfp.h
@@ -12,4 +12,10 @@
 
 int ecdh_skip_hash_extract_x_and_y(unsigned char *output, const unsigned char *x32, const unsigned char *y32, void *data);
 
+
+int ecdh_skip_hash_extract_only_x(unsigned char *output, const unsigned char *x32, const unsigned char *y32, void *data);
+
+
+
+
 #endif /* ecdh_no_hashfp_h */

--- a/Tests/K1Tests/TestCases/ECDH/ECDHTests.swift
+++ b/Tests/K1Tests/TestCases/ECDH/ECDHTests.swift
@@ -6,18 +6,54 @@
 //
 
 import Foundation
-import K1
+@testable import K1
 import XCTest
 
 final class ECDHTests: XCTestCase {
     
-    func testECDH() throws {
+    func testECDHPoint() throws {
         let alice = try K1.PrivateKey.generateNew()
         let bob = try K1.PrivateKey.generateNew()
         
-        let ab = try alice.sharedSecret(with: bob.publicKey)
-        let ba = try bob.sharedSecret(with: alice.publicKey)
+        let ab = try alice.ecdhPoint(with: bob.publicKey)
+        let ba = try bob.ecdhPoint(with: alice.publicKey)
         XCTAssertEqual(ab, ba, "Alice and Bob should be able to agree on the same secret")
+    }
+    
+    func testECDHLibsecp256k1() throws {
+        let alice = try K1.PrivateKey.generateNew()
+        let bob = try K1.PrivateKey.generateNew()
+        
+        let ab = try alice.ecdh(with: bob.publicKey)
+        let ba = try bob.ecdh(with: alice.publicKey)
+        XCTAssertEqual(ab, ba, "Alice and Bob should be able to agree on the same secret")
+    }
+    
+    func testECDHX963() throws {
+        let alice = try K1.PrivateKey.generateNew()
+        let bob = try K1.PrivateKey.generateNew()
+        
+        let ab = try alice.sharedSecretFromKeyAgreement(with: bob.publicKey)
+        let ba = try bob.sharedSecretFromKeyAgreement(with: alice.publicKey)
+        XCTAssertEqual(ab, ba, "Alice and Bob should be able to agree on the same secret")
+    }
+    
+    /// Test vectors from: https://crypto.stackexchange.com/q/57695
+    func test_crypto_stackexchange_vector() throws {
+        let privateKey1 = try PrivateKey(hex: "82fc9947e878fc7ed01c6c310688603f0a41c8e8704e5b990e8388343b0fd465")
+        let privateKey2 = try PrivateKey(hex: "5f706787ac72c1080275c1f398640fb07e9da0b124ae9734b28b8d0f01eda586")
+        
+        let libsecp256k1 = try privateKey1.ecdh(with: privateKey2.publicKey)
+        let ans1X963 = try privateKey1.sharedSecretFromKeyAgreement(with: privateKey2.publicKey).withUnsafeBytes({ Data($0) })
+        
+        XCTAssertEqual(libsecp256k1.hex, "5935d0476af9df2998efb60383adf2ff23bc928322cfbb738fca88e49d557d7e")
+        XCTAssertEqual(ans1X963.hex, "3a17fe5fa33c4f2c7e61799a65061214913f39bfcbee178ab351493d5ee17b2f")
+        
     }
 }
 
+extension K1.PrivateKey {
+    init(hex: String) throws {
+        self = try Self.import(rawRepresentation: Data(hex: hex))
+    }
+}

--- a/Tests/K1Tests/TestCases/ECDH/ECDHWychoproofTests.swift
+++ b/Tests/K1Tests/TestCases/ECDH/ECDHWychoproofTests.swift
@@ -78,10 +78,13 @@ private extension ECDHWychoproofTests {
                 var privateBytes = [UInt8]()
                 privateBytes = try padKeyIfNecessary(vector: testVector.privateKey)
                 let privateKey = try PrivateKey.import(rawRepresentation: privateBytes)
-                let expectedXComponent = try Data(hex: testVector.shared)
-                let sharedPublicKeyPoint = try privateKey.sharedSecret(with: publicKey)
-                let sharedPublicKeyXComponent = Data(sharedPublicKeyPoint[1..<33]) // slice out just X component
-                XCTAssertEqual(sharedPublicKeyXComponent, expectedXComponent, file: file, line: line)
+                
+                /// ANS1 X9.63 serialization of shared secret, returning a `CryptoKit.SharedSecret`
+                let sharedPublicKeyPoint = try privateKey.sharedSecretFromKeyAgreement(with: publicKey)
+                let got = sharedPublicKeyPoint.withUnsafeBytes {
+                    Data($0)
+                }
+                XCTAssertEqual(got.hex, testVector.shared, file: file, line: line)
             } catch {
                 if testVector.result != "invalid" {
                     XCTFail("Failed with error: \(String(describing: error)), test vector: \(String(describing: testVector))")

--- a/Tests/K1Tests/TestCases/ECDSA/ECDSASignatureTrezorTests.swift
+++ b/Tests/K1Tests/TestCases/ECDSA/ECDSASignatureTrezorTests.swift
@@ -45,7 +45,11 @@ private extension XCTestCase {
             XCTAssertTrue(try publicKey.isValidECDSASignature(expectedSignature, digest: messageDigest))
             
             let signatureFromMessage = try privateKey.ecdsaSignNonRecoverable(digest: messageDigest)
+            let signatureRecoverableFromMessage = try privateKey.ecdsaSignRecoverable(digest: messageDigest)
             XCTAssertEqual(signatureFromMessage, expectedSignature)
+            try XCTAssertEqual(signatureRecoverableFromMessage.nonRecoverable(), expectedSignature)
+            let recid = try signatureRecoverableFromMessage.compact().recoveryID
+            XCTAssertEqual(signatureRecoverableFromMessage.rawRepresentation.hex, expectedSignature.rawRepresentation.hex + "\(Data([UInt8(recid)]).hex)")
             numberOfTestsRun += 1
         }
         return .init(numberOfTestsRun: numberOfTestsRun, idsOmittedTests: [])


### PR DESCRIPTION
 one which is ANS1 x9.63 compatible, and one which is `libsecp256k1` compatible.