### PR TITLE
Add file '.spi.yml' to let SwiftPackageIndex.com host documentation.

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [K1]

--- a/Sources/K1/Support/FFI/API/ECDSA/FFI+ECDSA.swift
+++ b/Sources/K1/Support/FFI/API/ECDSA/FFI+ECDSA.swift
@@ -86,7 +86,11 @@ extension K1.ECDSA.SigningOptions.NonceFunction {
 			) -> Int32 /* Returns: 1 if a nonce was successfully generated. 0 will cause signing to fail. */ in
 
 				SecureBytes(count: Curve.Field.byteCount).withUnsafeBytes {
+					#if swift(>=5.8)
 					nonce32?.update(from: $0.baseAddress!.assumingMemoryBound(to: UInt8.self), count: $0.count)
+					#else
+					nonce32?.assign(from: $0.baseAddress!.assumingMemoryBound(to: UInt8.self), count: $0.count)
+					#endif
 				}
 
 				// Returns: 1 if a nonce was successfully generated. 0 will cause signing to fail.

--- a/Sources/K1/Support/FFI/API/ECDSA/FFI+ECDSA.swift
+++ b/Sources/K1/Support/FFI/API/ECDSA/FFI+ECDSA.swift
@@ -91,9 +91,7 @@ extension K1.ECDSA.SigningOptions.NonceFunction {
 				#if swift(>=5.8)
 				nonce32?.update(from: secureBytes.bytes, count: count)
 				#else
-				secureBytes.withUnsafeBytes {
-					nonce32?.assign(from: $0.baseAddress!.assumingMemoryBound(to: UInt8.self), count: count)
-				}
+				nonce32?.assign(from: secureBytes.bytes, count: count)
 				#endif
 
 				// Returns: 1 if a nonce was successfully generated. 0 will cause signing to fail.

--- a/Sources/K1/Support/FFI/API/ECDSA/FFI+ECDSA.swift
+++ b/Sources/K1/Support/FFI/API/ECDSA/FFI+ECDSA.swift
@@ -86,7 +86,7 @@ extension K1.ECDSA.SigningOptions.NonceFunction {
 			) -> Int32 /* Returns: 1 if a nonce was successfully generated. 0 will cause signing to fail. */ in
 
 				SecureBytes(count: Curve.Field.byteCount).withUnsafeBytes {
-					nonce32?.assign(from: $0.baseAddress!.assumingMemoryBound(to: UInt8.self), count: $0.count)
+					nonce32?.update(from: $0.baseAddress!.assumingMemoryBound(to: UInt8.self), count: $0.count)
 				}
 
 				// Returns: 1 if a nonce was successfully generated. 0 will cause signing to fail.

--- a/Sources/K1/Support/FFI/API/ECDSA/FFI+ECDSA.swift
+++ b/Sources/K1/Support/FFI/API/ECDSA/FFI+ECDSA.swift
@@ -85,13 +85,16 @@ extension K1.ECDSA.SigningOptions.NonceFunction {
 				_: UInt32 // In: how many iterations we have tried to find a nonce. This will almost always be 0, but different attempt values are required to result in a different nonce.
 			) -> Int32 /* Returns: 1 if a nonce was successfully generated. 0 will cause signing to fail. */ in
 
-				SecureBytes(count: Curve.Field.byteCount).withUnsafeBytes {
-					#if swift(>=5.8)
-					nonce32?.update(from: $0.baseAddress!.assumingMemoryBound(to: UInt8.self), count: $0.count)
-					#else
-					nonce32?.assign(from: $0.baseAddress!.assumingMemoryBound(to: UInt8.self), count: $0.count)
-					#endif
+				let count = Curve.Field.byteCount
+				let secureBytes = SecureBytes(count: count)
+
+				#if swift(>=5.8)
+				nonce32?.update(from: secureBytes.bytes, count: count)
+				#else
+				secureBytes.withUnsafeBytes {
+					nonce32?.assign(from: $0.baseAddress!.assumingMemoryBound(to: UInt8.self), count: count)
 				}
+				#endif
 
 				// Returns: 1 if a nonce was successfully generated. 0 will cause signing to fail.
 				return 1


### PR DESCRIPTION
As per SwiftPackageIndex's guide: https://swiftpackageindex.com/SwiftPackageIndex/SPIManifest/0.15.1/documentation/spimanifest/commonusecases

We also fix a compilation warning and upgrade [to new API's of `UnsafeMutableBufferPointer` from SE-0370](https://github.com/apple/swift-evolution/blob/main/proposals/0370-pointer-family-initialization-improvements.md)