### PR TITLE
[BREAK API] ECDSA.Recoverable to ECDSAWithKeyRecovery & ECDSA.NonRecoverable to ECDSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ The API of K1 maps almost 1:1 with Apple's [CryptoKit][ck], vendoring a set of k
 Just like that K1 vendors these key pairs:
 - `K1.KeyAgreement.PrivateKey` / `K1.KeyAgreement.PublicKey` for key agreement (ECDH)
 - `K1.Schnorr.PrivateKey` / `K1.Schnorr.PublicKey` for sign / verify methods using Schnorr signature scheme
-- `K1.ECDSA.Recoverable.PrivateKey` / `K1.ECDSA.Recoverable.PublicKey` for sign / verify methods using ECDSA (producing/validating signature where public key is recoverable)
-- `K1.ECDSA.NonRecoverable.PrivateKey` / `K1.ECDSA.NonRecoverable.PublicKey` for sign / verify methods using ECDSA (producing/validating signature where public key is **not** recoverable)
+- `K1.ECDSAWithKeyRecovery.PrivateKey` / `K1.ECDSAWithKeyRecovery.PublicKey` for sign / verify methods using ECDSA (producing/validating signature where public key is recoverable)
+- `K1.ECDSA.PrivateKey` / `K1.ECDSA.PublicKey` for sign / verify methods using ECDSA (producing/validating signature where public key is **not** recoverable)
 
 Just like you can convert between e.g. `Curve25519.KeyAgreement.PrivateKey` and  `Curve25519.Signing.PrivateKey` back and forth using any of the initializers and serializer, you can convert between all PrivateKeys and all PublicKeys of all features in K1.
 
@@ -64,8 +64,8 @@ Furthermore, all PublicKeys's have these additional APIs:
 ## ECDSA (Elliptic Curve Digital Signature Algorithm)
 
 There exists two set of ECDSA key pairs:
-- A key pair for signatures from which you can recover the public key, specifically: `K1.ECDSA.Recoverable.PrivateKey` and `K1.ECDSA.Recoverable.PublicKey`
-- A key pair for signatures from which you can **not** recover the public key, specifically: `K1.ECDSA.NonRecoverable.PrivateKey` and `K1.ECDSA.NonRecoverable.PublicKey`
+- A key pair for signatures from which you can recover the public key, specifically: `K1.ECDSAWithKeyRecovery.PrivateKey` and `K1.ECDSAWithKeyRecovery.PublicKey`
+- A key pair for signatures from which you can **not** recover the public key, specifically: `K1.ECDSA.PrivateKey` and `K1.ECDSA.PublicKey`
 
 For each private key there exists two different `signature:for:options` (one taking hashed data and taking `Digest` as argument) methods and one `signature:forUnhashed:options`.
 
@@ -76,7 +76,7 @@ The `option` is a `K1.ECDSA.SigningOptions` struct, which by default specifies [
 #### Sign
 
 ```swift
-let alice = K1.ECDA.NonRecovarable.PrivateKey()
+let alice = K1.ECDSA.PrivateKey()
 ```
 
 ##### Hashed (Data)
@@ -109,8 +109,8 @@ let signature = try alice.signature(forUnhashed: message)
 
 ```swift
 let hashedMessage: Data = // from somewhere
-let publicKey: K1.ECDSA.NonRecoverable.PublicKey = alice.publcKey
-let signature: K1.ECDSA.NonRecoverable.Signature // from above
+let publicKey: K1.ECDSA.PublicKey = alice.publcKey
+let signature: K1.ECDSA.Signature // from above
 
 assert(
     publicKey.isValidSignature(signature, hashed: hashedMessage)
@@ -122,7 +122,7 @@ assert(
 ```swift
 let message: Data = // from somewhere
 let digest = SHA256.hash(data: message)
-let signature: K1.ECDSA.NonRecoverable.Signature // from above
+let signature: K1.ECDSA.Signature // from above
 
 assert(
     publicKey.isValidSignature(signature, digest: digest)
@@ -133,7 +133,7 @@ assert(
 
 ```swift
 let message: Data = // from somewhere
-let signature: K1.ECDSA.NonRecoverable.Signature // from above
+let signature: K1.ECDSA.Signature // from above
 
 assert(
     publicKey.isValidSignature(signature, unhashed: message)
@@ -146,11 +146,11 @@ assert(
 All signing and validation APIs are identical to the `NonRecoverable` namespace.
 
 ```swift
-let alice = K1.ECDA.Recovarable.PrivateKey()
+let alice = K1.ECDSA.PrivateKey()
 let message: Data = // from somewhere
 let digest = SHA256.hash(data: message)
-let signature: K1.ECDSA.Recoverable.Signature = try alice.signature(for: digest)
-let publicKey: K1.ECDSA.Recoverable.PublicKey = alice.publicKey
+let signature: K1.ECDSAWithKeyRecovery.Signature = try alice.signature(for: digest)
+let publicKey: K1.ECDSAWithKeyRecovery.PublicKey = alice.publicKey
 assert(
     publicKey.isValidSignature(signature, digest: digest)
 ) // PASS

--- a/Sources/K1/K1/ECDSA/ECDSA.swift
+++ b/Sources/K1/K1/ECDSA/ECDSA.swift
@@ -1,6 +1,6 @@
 // MARK: - K1.ECDSA
 extension K1 {
-	/// A mechanism used to create or verify a cryptographic signature using the `secp256k1` elliptic curve digital signature algorithm (ECDSA).
+	/// A mechanism used to create or verify a cryptographic signature using the `secp256k1` elliptic curve digital signature algorithm (ECDSA), signatures that do not offer recovery of the public key.
 	public enum ECDSA {}
 }
 

--- a/Sources/K1/K1/ECDSA/ECDSASignatureNonRecoverable.swift
+++ b/Sources/K1/K1/ECDSA/ECDSASignatureNonRecoverable.swift
@@ -2,20 +2,12 @@ import protocol CryptoKit.Digest
 import struct CryptoKit.SHA256
 import Foundation
 
-// MARK: - K1.ECDSA.NonRecoverable
+// MARK: - K1.ECDSA.Signature
 extension K1.ECDSA {
-	/// A mechanism used to create or verify a cryptographic signature using the `secp256k1` elliptic curve digital signature algorithm (ECDSA), signatures that do not offer recovery of the public key.
-	public enum NonRecoverable {
-		// Just a namespace
-	}
-}
-
-// MARK: - K1.ECDSA.NonRecoverable.Signature
-extension K1.ECDSA.NonRecoverable {
 	/// A `secp256k1` elliptic curve digital signature algorithm (ECDSA) signature,
 	/// from which users can recover a public key with the message that was signed.
 	public struct Signature: Sendable, Hashable, ContiguousBytes {
-		typealias Wrapped = FFI.ECDSA.NonRecoverable.Wrapped
+		typealias Wrapped = FFI.ECDSA.Wrapped
 		internal let wrapped: Wrapped
 
 		init(wrapped: Wrapped) {
@@ -25,12 +17,12 @@ extension K1.ECDSA.NonRecoverable {
 }
 
 // MARK: Inits
-extension K1.ECDSA.NonRecoverable.Signature {
+extension K1.ECDSA.Signature {
 	/// Creates a `secp256k1` ECDSA signature from a Distinguished Encoding Rules (DER) encoded representation.
 	/// - Parameter derRepresentation: A DER-encoded representation of the signature.
 	public init(derRepresentation: some DataProtocol) throws {
 		try self.init(
-			wrapped: FFI.ECDSA.NonRecoverable.from(derRepresentation: [UInt8](derRepresentation))
+			wrapped: FFI.ECDSA.from(derRepresentation: [UInt8](derRepresentation))
 		)
 	}
 
@@ -44,20 +36,20 @@ extension K1.ECDSA.NonRecoverable.Signature {
 	/// [rfc]: https://tools.ietf.org/html/rfc4754
 	public init(rawRepresentation: some DataProtocol) throws {
 		try self.init(
-			wrapped: FFI.ECDSA.NonRecoverable.from(compactBytes: [UInt8](rawRepresentation))
+			wrapped: FFI.ECDSA.from(compactBytes: [UInt8](rawRepresentation))
 		)
 	}
 }
 
 // MARK: ContiguousBytes
-extension K1.ECDSA.NonRecoverable.Signature {
+extension K1.ECDSA.Signature {
 	public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
 		try wrapped.withUnsafeBytes(body)
 	}
 }
 
 // MARK: Serialize
-extension K1.ECDSA.NonRecoverable.Signature {
+extension K1.ECDSA.Signature {
 	var internalRepresentation: Data {
 		Data(wrapped.bytes)
 	}
@@ -68,7 +60,7 @@ extension K1.ECDSA.NonRecoverable.Signature {
 	/// `libsecp256k1` this representation is called "compact".
 	public var rawRepresentation: Data {
 		do {
-			return try FFI.ECDSA.NonRecoverable.compact(wrapped)
+			return try FFI.ECDSA.compact(wrapped)
 		} catch {
 			fatalError("Should never fail to convert ECDSA signatures to rawRepresentation.")
 		}
@@ -78,7 +70,7 @@ extension K1.ECDSA.NonRecoverable.Signature {
 	/// `secp256k1` ECDSA non recoverable signature.
 	public var derRepresentation: Data {
 		do {
-			return try FFI.ECDSA.NonRecoverable.der(wrapped)
+			return try FFI.ECDSA.der(wrapped)
 		} catch {
 			fatalError("Should never fail to convert ECDSA signatures to DER representation.")
 		}
@@ -86,7 +78,7 @@ extension K1.ECDSA.NonRecoverable.Signature {
 }
 
 // MARK: Recover
-extension K1.ECDSA.NonRecoverable.Signature {
+extension K1.ECDSA.Signature {
 	/// Recovers a public key from a `secp256k1` ECDSA signature, the message signed
 	/// and a `recoveryID`.
 	///
@@ -96,25 +88,25 @@ extension K1.ECDSA.NonRecoverable.Signature {
 	/// - Returns: The public key which corresponds to the private key which used to produce this
 	/// signature by signing the `message`.
 	public func recoverPublicKey(
-		recoveryID: K1.ECDSA.Recoverable.Signature.RecoveryID,
+		recoveryID: K1.ECDSAWithKeyRecovery.Signature.RecoveryID,
 		message: some DataProtocol
-	) throws -> K1.ECDSA.NonRecoverable.PublicKey {
-		let wrapped = try FFI.ECDSA.NonRecoverable.recoverPublicKey(
+	) throws -> K1.ECDSA.PublicKey {
+		let wrapped = try FFI.ECDSA.recoverPublicKey(
 			self.wrapped,
 			recoveryID: recoveryID.recid,
 			message: [UInt8](message)
 		)
 		let impl = K1._PublicKeyImplementation(wrapped: wrapped)
-		return K1.ECDSA.NonRecoverable.PublicKey(impl: impl)
+		return K1.ECDSA.PublicKey(impl: impl)
 	}
 }
 
-extension K1.ECDSA.NonRecoverable.Signature {
-	internal static let byteCount = FFI.ECDSA.Recoverable.byteCount
+extension K1.ECDSA.Signature {
+	internal static let byteCount = FFI.ECDSAWithKeyRecovery.byteCount
 }
 
 // MARK: Equatable
-extension K1.ECDSA.NonRecoverable.Signature {
+extension K1.ECDSA.Signature {
 	/// Compares two ECDSA signatures.
 	public static func == (lhs: Self, rhs: Self) -> Bool {
 		lhs.wrapped.withUnsafeBytes { lhsBytes in
@@ -126,7 +118,7 @@ extension K1.ECDSA.NonRecoverable.Signature {
 }
 
 // MARK: Hashable
-extension K1.ECDSA.NonRecoverable.Signature {
+extension K1.ECDSA.Signature {
 	public func hash(into hasher: inout Hasher) {
 		wrapped.withUnsafeBytes {
 			hasher.combine(bytes: $0)

--- a/Sources/K1/K1/ECDSA/ECDSASignatureRecoverable.swift
+++ b/Sources/K1/K1/ECDSA/ECDSASignatureRecoverable.swift
@@ -2,20 +2,20 @@ import protocol CryptoKit.Digest
 import struct CryptoKit.SHA256
 import Foundation
 
-// MARK: - K1.ECDSA.Recoverable
-extension K1.ECDSA {
+// MARK: - K1.ECDSAWithKeyRecovery
+extension K1 {
 	/// A mechanism used to create or verify a cryptographic signature using the `secp256k1` elliptic curve digital signature algorithm (ECDSA), signatures that do offers recovery of the public key.
-	public enum Recoverable {
+	public enum ECDSAWithKeyRecovery {
 		// Just a namespace
 	}
 }
 
-// MARK: - K1.ECDSA.Recoverable.Signature
-extension K1.ECDSA.Recoverable {
+// MARK: - K1.ECDSAWithKeyRecovery.Signature
+extension K1.ECDSAWithKeyRecovery {
 	/// A `secp256k1` elliptic curve digital signature algorithm (ECDSA) signature,
 	/// from which users **cannot** recover the public key, not without the `RecoveryID`.
 	public struct Signature: Sendable, Hashable, ContiguousBytes {
-		typealias Wrapped = FFI.ECDSA.Recoverable.Wrapped
+		typealias Wrapped = FFI.ECDSAWithKeyRecovery.Wrapped
 		internal let wrapped: Wrapped
 
 		internal init(wrapped: Wrapped) {
@@ -25,11 +25,11 @@ extension K1.ECDSA.Recoverable {
 }
 
 // MARK: Init
-extension K1.ECDSA.Recoverable.Signature {
+extension K1.ECDSAWithKeyRecovery.Signature {
 	/// Compact aka `IEEE P1363` aka `R||S`.
 	public init(compact: Compact) throws {
 		try self.init(
-			wrapped: FFI.ECDSA.Recoverable.deserialize(
+			wrapped: FFI.ECDSAWithKeyRecovery.deserialize(
 				compact: [UInt8](compact.compact),
 				recoveryID: compact.recoveryID.recid
 			)
@@ -45,27 +45,27 @@ extension K1.ECDSA.Recoverable.Signature {
 		internalRepresentation: some DataProtocol
 	) throws {
 		try self.init(
-			wrapped: FFI.ECDSA.Recoverable.deserialize(rawRepresentation: internalRepresentation)
+			wrapped: FFI.ECDSAWithKeyRecovery.deserialize(rawRepresentation: internalRepresentation)
 		)
 	}
 }
 
 // MARK: ContiguousBytes
-extension K1.ECDSA.Recoverable.Signature {
+extension K1.ECDSAWithKeyRecovery.Signature {
 	public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
 		try wrapped.withUnsafeBytes(body)
 	}
 }
 
 // MARK: Serialize
-extension K1.ECDSA.Recoverable.Signature {
+extension K1.ECDSAWithKeyRecovery.Signature {
 	internal var internalRepresentation: Data {
 		Data(wrapped.bytes)
 	}
 
 	/// Compact aka `IEEE P1363` aka `R||S` with `RecoveryID`
 	public func compact() throws -> Compact {
-		let (rs, recid) = try FFI.ECDSA.Recoverable.serializeCompact(
+		let (rs, recid) = try FFI.ECDSAWithKeyRecovery.serializeCompact(
 			wrapped
 		)
 		return try .init(
@@ -95,7 +95,7 @@ extension K1.ECDSA.Recoverable.Signature {
 	}
 }
 
-extension K1.ECDSA.Recoverable.Signature.Compact {
+extension K1.ECDSAWithKeyRecovery.Signature.Compact {
 	public static let byteCountRS = 2 * Curve.Field.byteCount
 	public static let byteCount = Self.byteCountRS + 1
 
@@ -151,7 +151,7 @@ extension K1.ECDSA.Recoverable.Signature.Compact {
 	}
 }
 
-extension K1.ECDSA.Recoverable.Signature.RecoveryID {
+extension K1.ECDSAWithKeyRecovery.Signature.RecoveryID {
 	var vData: Data {
 		Data(
 			[UInt8(rawValue)]
@@ -160,7 +160,7 @@ extension K1.ECDSA.Recoverable.Signature.RecoveryID {
 }
 
 // MARK: Recovery
-extension K1.ECDSA.Recoverable.Signature {
+extension K1.ECDSAWithKeyRecovery.Signature {
 	/// Recovers a public key from a `secp256k1` this ECDSA signature and the message signed.
 	///
 	/// - Parameters:
@@ -169,27 +169,27 @@ extension K1.ECDSA.Recoverable.Signature {
 	/// signature by signing the `message`.
 	public func recoverPublicKey(
 		message: some DataProtocol
-	) throws -> K1.ECDSA.Recoverable.PublicKey {
-		let wrapped = try FFI.ECDSA.Recoverable.recover(wrapped, message: [UInt8](message))
+	) throws -> K1.ECDSAWithKeyRecovery.PublicKey {
+		let wrapped = try FFI.ECDSAWithKeyRecovery.recover(wrapped, message: [UInt8](message))
 		let impl = K1._PublicKeyImplementation(wrapped: wrapped)
-		return K1.ECDSA.Recoverable.PublicKey(
+		return K1.ECDSAWithKeyRecovery.PublicKey(
 			impl: impl
 		)
 	}
 }
 
 // MARK: Conversion
-extension K1.ECDSA.Recoverable.Signature {
+extension K1.ECDSAWithKeyRecovery.Signature {
 	/// Converts this recoverable ECDSA signature to a non-recoverable version.
-	public func nonRecoverable() throws -> K1.ECDSA.NonRecoverable.Signature {
-		try K1.ECDSA.NonRecoverable.Signature(
-			wrapped: FFI.ECDSA.Recoverable.nonRecoverable(self.wrapped)
+	public func nonRecoverable() throws -> K1.ECDSA.Signature {
+		try K1.ECDSA.Signature(
+			wrapped: FFI.ECDSAWithKeyRecovery.nonRecoverable(self.wrapped)
 		)
 	}
 }
 
 // MARK: Equatable
-extension K1.ECDSA.Recoverable.Signature {
+extension K1.ECDSAWithKeyRecovery.Signature {
 	/// Compares two ECDSA signatures.
 	public static func == (lhs: Self, rhs: Self) -> Bool {
 		lhs.wrapped.withUnsafeBytes { lhsBytes in
@@ -201,7 +201,7 @@ extension K1.ECDSA.Recoverable.Signature {
 }
 
 // MARK: Hashable
-extension K1.ECDSA.Recoverable.Signature {
+extension K1.ECDSAWithKeyRecovery.Signature {
 	public func hash(into hasher: inout Hasher) {
 		wrapped.withUnsafeBytes {
 			hasher.combine(bytes: $0)

--- a/Sources/K1/K1/ECDSA/RecoveryID.swift
+++ b/Sources/K1/K1/ECDSA/RecoveryID.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-// MARK: - K1.ECDSA.Recoverable.Signature.RecoveryID
-extension K1.ECDSA.Recoverable.Signature {
+// MARK: - K1.ECDSAWithKeyRecovery.Signature.RecoveryID
+extension K1.ECDSAWithKeyRecovery.Signature {
 	public enum RecoveryID: UInt8, Sendable, Hashable, Codable {
 		case _0 = 0
 		case _1 = 1
@@ -14,7 +14,7 @@ extension K1.ECDSA.Recoverable.Signature {
 	}
 }
 
-extension K1.ECDSA.Recoverable.Signature.RecoveryID {
+extension K1.ECDSAWithKeyRecovery.Signature.RecoveryID {
 	public init(byte: UInt8) throws {
 		guard let self_ = Self(rawValue: byte) else {
 			throw K1.Error.invalidParameter

--- a/Sources/K1/K1/Keys/Keys.generated.swift
+++ b/Sources/K1/K1/Keys/Keys.generated.swift
@@ -402,13 +402,13 @@ extension K1.Schnorr {
 	}
 }
 
-extension K1.ECDSA.NonRecoverable {
-	// MARK: ECDSA.NonRecoverable + PrivateKey
+extension K1.ECDSA {
+	// MARK: ECDSA + PrivateKey
 	/// A `secp256k1` private key used to create cryptographic signatures,
 	/// more specifically ECDSA signatures, that do not offer recovery of the public key.
 	public struct PrivateKey: Sendable, Hashable {
 		typealias Impl = K1._PrivateKeyImplementation
-		public typealias PublicKey = K1.ECDSA.NonRecoverable.PublicKey
+		public typealias PublicKey = K1.ECDSA.PublicKey
 
 		internal let impl: Impl
 		internal let publicKeyImpl: K1._PublicKeyImplementation
@@ -506,7 +506,7 @@ extension K1.ECDSA.NonRecoverable {
 		}
 	}
 
-	// MARK: ECDSA.NonRecoverable + PublicKey
+	// MARK: ECDSA + PublicKey
 	/// A `secp256k1` public key used to verify cryptographic signatures,
 	/// more specifically ECDSA signatures, that do not offer recovery of the public key.
 	public struct PublicKey: Sendable, Hashable {
@@ -602,13 +602,13 @@ extension K1.ECDSA.NonRecoverable {
 	}
 }
 
-extension K1.ECDSA.Recoverable {
-	// MARK: ECDSA.Recoverable + PrivateKey
+extension K1.ECDSAWithKeyRecovery {
+	// MARK: ECDSAWithKeyRecovery + PrivateKey
 	/// A `secp256k1` private key used to create cryptographic signatures,
 	/// more specifically ECDSA signatures that offers recovery of the public key.
 	public struct PrivateKey: Sendable, Hashable {
 		typealias Impl = K1._PrivateKeyImplementation
-		public typealias PublicKey = K1.ECDSA.Recoverable.PublicKey
+		public typealias PublicKey = K1.ECDSAWithKeyRecovery.PublicKey
 
 		internal let impl: Impl
 		internal let publicKeyImpl: K1._PublicKeyImplementation
@@ -706,7 +706,7 @@ extension K1.ECDSA.Recoverable {
 		}
 	}
 
-	// MARK: ECDSA.Recoverable + PublicKey
+	// MARK: ECDSAWithKeyRecovery + PublicKey
 	/// A `secp256k1` public key used to verify cryptographic signatures.
 	/// more specifically ECDSA signatures that offers recovery of the public key.
 	public struct PublicKey: Sendable, Hashable {
@@ -814,14 +814,14 @@ extension K1.Schnorr.PrivateKey: _K1PrivateKeyProtocol {}
 // MARK: - K1.Schnorr.PublicKey + _K1PublicKeyProtocol
 extension K1.Schnorr.PublicKey: _K1PublicKeyProtocol {}
 
-// MARK: - K1.ECDSA.NonRecoverable.PrivateKey + _K1PrivateKeyProtocol
-extension K1.ECDSA.NonRecoverable.PrivateKey: _K1PrivateKeyProtocol {}
+// MARK: - K1.ECDSA.PrivateKey + _K1PrivateKeyProtocol
+extension K1.ECDSA.PrivateKey: _K1PrivateKeyProtocol {}
 
-// MARK: - K1.ECDSA.NonRecoverable.PublicKey + _K1PublicKeyProtocol
-extension K1.ECDSA.NonRecoverable.PublicKey: _K1PublicKeyProtocol {}
+// MARK: - K1.ECDSA.PublicKey + _K1PublicKeyProtocol
+extension K1.ECDSA.PublicKey: _K1PublicKeyProtocol {}
 
-// MARK: - K1.ECDSA.Recoverable.PrivateKey + _K1PrivateKeyProtocol
-extension K1.ECDSA.Recoverable.PrivateKey: _K1PrivateKeyProtocol {}
+// MARK: - K1.ECDSAWithKeyRecovery.PrivateKey + _K1PrivateKeyProtocol
+extension K1.ECDSAWithKeyRecovery.PrivateKey: _K1PrivateKeyProtocol {}
 
-// MARK: - K1.ECDSA.Recoverable.PublicKey + _K1PublicKeyProtocol
-extension K1.ECDSA.Recoverable.PublicKey: _K1PublicKeyProtocol {}
+// MARK: - K1.ECDSAWithKeyRecovery.PublicKey + _K1PublicKeyProtocol
+extension K1.ECDSAWithKeyRecovery.PublicKey: _K1PublicKeyProtocol {}

--- a/Sources/K1/K1/Keys/Keys.swift.gyb
+++ b/Sources/K1/K1/Keys/Keys.swift.gyb
@@ -21,14 +21,14 @@ import Foundation
 			"docPK": "/// A `secp256k1` public key used to verify cryptographic signatures,\n\t/// more specifically Schnorr signatures"
 		},
 		{
-			"feature": "ECDSA.NonRecoverable",
+			"feature": "ECDSA",
 			"purposeSK": "signing",
 			"purposePK": "verifying signatures",
 			"docSK": "/// A `secp256k1` private key used to create cryptographic signatures,\n\t/// more specifically ECDSA signatures, that do not offer recovery of the public key.",
 			"docPK": "/// A `secp256k1` public key used to verify cryptographic signatures,\n\t/// more specifically ECDSA signatures, that do not offer recovery of the public key."
 		},
 		{
-			"feature": "ECDSA.Recoverable",
+			"feature": "ECDSAWithKeyRecovery",
 			"purposeSK": "signing",
 			"purposePK": "verifying signatures",
 			"docSK": "/// A `secp256k1` private key used to create cryptographic signatures,\n\t/// more specifically ECDSA signatures that offers recovery of the public key.",

--- a/Sources/K1/K1/Signing/Signing.generated.swift
+++ b/Sources/K1/K1/Signing/Signing.generated.swift
@@ -6,8 +6,8 @@ import protocol CryptoKit.Digest
 import struct CryptoKit.SHA256
 import Foundation
 
-// MARK: Sign + ECDSA.NonRecoverable
-extension K1.ECDSA.NonRecoverable.PrivateKey {
+// MARK: Sign + ECDSA
+extension K1.ECDSA.PrivateKey {
 	/// Generates an Elliptic Curve Digital Signature Algorithm (ECDSA) non recoverable signature of _hashed_ data you provide over the `secp256k1` elliptic curve.
 	/// - Parameters:
 	///   - hashed: The _hashed_ data to sign.
@@ -16,9 +16,9 @@ extension K1.ECDSA.NonRecoverable.PrivateKey {
 	public func signature(
 		for hashed: some DataProtocol,
 		options: K1.ECDSA.SigningOptions = .default
-	) throws -> K1.ECDSA.NonRecoverable.Signature {
-		try K1.ECDSA.NonRecoverable.Signature(
-			wrapped: FFI.ECDSA.NonRecoverable.sign(
+	) throws -> K1.ECDSA.Signature {
+		try K1.ECDSA.Signature(
+			wrapped: FFI.ECDSA.sign(
 				hashedMessage: [UInt8](hashed),
 				privateKey: impl.wrapped,
 				options: options
@@ -34,7 +34,7 @@ extension K1.ECDSA.NonRecoverable.PrivateKey {
 	public func signature(
 		for digest: some Digest,
 		options: K1.ECDSA.SigningOptions = .default
-	) throws -> K1.ECDSA.NonRecoverable.Signature {
+	) throws -> K1.ECDSA.Signature {
 		try signature(
 			for: Data(digest),
 			options: options
@@ -49,7 +49,7 @@ extension K1.ECDSA.NonRecoverable.PrivateKey {
 	public func signature(
 		forUnhashed unhashed: some DataProtocol,
 		options: K1.ECDSA.SigningOptions = .default
-	) throws -> K1.ECDSA.NonRecoverable.Signature {
+	) throws -> K1.ECDSA.Signature {
 		try signature(
 			for: SHA256.hash(data: unhashed),
 			options: options
@@ -57,8 +57,8 @@ extension K1.ECDSA.NonRecoverable.PrivateKey {
 	}
 }
 
-// MARK: Sign + ECDSA.Recoverable
-extension K1.ECDSA.Recoverable.PrivateKey {
+// MARK: Sign + ECDSAWithKeyRecovery
+extension K1.ECDSAWithKeyRecovery.PrivateKey {
 	/// Generates an Elliptic Curve Digital Signature Algorithm (ECDSA) recoverable signature of _hashed_ data you provide over the `secp256k1` elliptic curve.
 	/// - Parameters:
 	///   - hashed: The _hashed_ data to sign.
@@ -67,9 +67,9 @@ extension K1.ECDSA.Recoverable.PrivateKey {
 	public func signature(
 		for hashed: some DataProtocol,
 		options: K1.ECDSA.SigningOptions = .default
-	) throws -> K1.ECDSA.Recoverable.Signature {
-		try K1.ECDSA.Recoverable.Signature(
-			wrapped: FFI.ECDSA.Recoverable.sign(
+	) throws -> K1.ECDSAWithKeyRecovery.Signature {
+		try K1.ECDSAWithKeyRecovery.Signature(
+			wrapped: FFI.ECDSAWithKeyRecovery.sign(
 				hashedMessage: [UInt8](hashed),
 				privateKey: impl.wrapped,
 				options: options
@@ -85,7 +85,7 @@ extension K1.ECDSA.Recoverable.PrivateKey {
 	public func signature(
 		for digest: some Digest,
 		options: K1.ECDSA.SigningOptions = .default
-	) throws -> K1.ECDSA.Recoverable.Signature {
+	) throws -> K1.ECDSAWithKeyRecovery.Signature {
 		try signature(
 			for: Data(digest),
 			options: options
@@ -100,7 +100,7 @@ extension K1.ECDSA.Recoverable.PrivateKey {
 	public func signature(
 		forUnhashed unhashed: some DataProtocol,
 		options: K1.ECDSA.SigningOptions = .default
-	) throws -> K1.ECDSA.Recoverable.Signature {
+	) throws -> K1.ECDSAWithKeyRecovery.Signature {
 		try signature(
 			for: SHA256.hash(data: unhashed),
 			options: options

--- a/Sources/K1/K1/Signing/Signing.swift.gyb
+++ b/Sources/K1/K1/Signing/Signing.swift.gyb
@@ -10,14 +10,14 @@ import protocol CryptoKit.Digest
 	VARIANTS_OF_FEATURE = [
 		{
 			"scheme": "ECDSA",
-			"feature": "ECDSA.NonRecoverable",
+			"feature": "ECDSA",
 			"variant": "an Elliptic Curve Digital Signature Algorithm (ECDSA) non recoverable",
 			"docSignParameterOptions": "Whether or not to consider malleable signatures valid",
 			"docSignReturnExtra": " The signing algorithm uses deterministic or random nonces, dependent on `options`, thus either deterministically producing the same signature or the same data and key, or different on every call."
 		},
 		{
 			"scheme": "ECDSA",
-			"feature": "ECDSA.Recoverable",
+			"feature": "ECDSAWithKeyRecovery",
 			"variant": "an Elliptic Curve Digital Signature Algorithm (ECDSA) recoverable",
 			"docSignParameterOptions": "Whether or not to consider malleable signatures valid",
 			"docSignReturnExtra": " The signing algorithm uses deterministic or random nonces, dependent on `options`, thus either deterministically producing the same signature or the same data and key, or different on every call."

--- a/Sources/K1/K1/Validation/Validation.generated.swift
+++ b/Sources/K1/K1/Validation/Validation.generated.swift
@@ -6,8 +6,8 @@ import protocol CryptoKit.Digest
 import struct CryptoKit.SHA256
 import Foundation
 
-// MARK: Verify + ECDSA.NonRecoverable
-extension K1.ECDSA.NonRecoverable.PublicKey {
+// MARK: Verify + ECDSA
+extension K1.ECDSA.PublicKey {
 	/// Verifies an Elliptic Curve Digital Signature Algorithm (ECDSA) non recoverable signature on some _hash_ over the `secp256k1` elliptic curve.
 	/// - Parameters:
 	///   - signature: The an Elliptic Curve Digital Signature Algorithm (ECDSA) non recoverable signature to check against the _hashed_ data.
@@ -15,12 +15,12 @@ extension K1.ECDSA.NonRecoverable.PublicKey {
 	///   - options: Whether or not to consider malleable signatures valid.
 	/// - Returns: A Boolean value that’s true if the an Elliptic Curve Digital Signature Algorithm (ECDSA) non recoverable signature is valid for the given _hashed_ data.
 	public func isValidSignature(
-		_ signature: K1.ECDSA.NonRecoverable.Signature,
+		_ signature: K1.ECDSA.Signature,
 		hashed: some DataProtocol,
 		options: K1.ECDSA.ValidationOptions = .default
 	) -> Bool {
 		do {
-			return try FFI.ECDSA.NonRecoverable.isValid(
+			return try FFI.ECDSA.isValid(
 				signature: signature.wrapped,
 				publicKey: self.impl.wrapped,
 				message: [UInt8](hashed),
@@ -38,7 +38,7 @@ extension K1.ECDSA.NonRecoverable.PublicKey {
 	///   - options: Whether or not to consider malleable signatures valid.
 	/// - Returns: A Boolean value that’s true if the an Elliptic Curve Digital Signature Algorithm (ECDSA) non recoverable signature is valid for the given digest.
 	public func isValidSignature(
-		_ signature: K1.ECDSA.NonRecoverable.Signature,
+		_ signature: K1.ECDSA.Signature,
 		digest: some Digest,
 		options: K1.ECDSA.ValidationOptions = .default
 	) -> Bool {
@@ -60,7 +60,7 @@ extension K1.ECDSA.NonRecoverable.PublicKey {
 	///   - options: Whether or not to consider malleable signatures valid.
 	/// - Returns: A Boolean value that’s true if the an Elliptic Curve Digital Signature Algorithm (ECDSA) non recoverable signature is valid for the given block of data.
 	public func isValidSignature(
-		_ signature: K1.ECDSA.NonRecoverable.Signature,
+		_ signature: K1.ECDSA.Signature,
 		unhashed: some DataProtocol,
 		options: K1.ECDSA.ValidationOptions = .default
 	) -> Bool {
@@ -72,8 +72,8 @@ extension K1.ECDSA.NonRecoverable.PublicKey {
 	}
 }
 
-// MARK: Verify + ECDSA.Recoverable
-extension K1.ECDSA.Recoverable.PublicKey {
+// MARK: Verify + ECDSAWithKeyRecovery
+extension K1.ECDSAWithKeyRecovery.PublicKey {
 	/// Verifies an Elliptic Curve Digital Signature Algorithm (ECDSA) recoverable signature on some _hash_ over the `secp256k1` elliptic curve.
 	/// - Parameters:
 	///   - signature: The an Elliptic Curve Digital Signature Algorithm (ECDSA) recoverable signature to check against the _hashed_ data.
@@ -81,12 +81,12 @@ extension K1.ECDSA.Recoverable.PublicKey {
 	///   - options: Whether or not to consider malleable signatures valid.
 	/// - Returns: A Boolean value that’s true if the an Elliptic Curve Digital Signature Algorithm (ECDSA) recoverable signature is valid for the given _hashed_ data.
 	public func isValidSignature(
-		_ signature: K1.ECDSA.Recoverable.Signature,
+		_ signature: K1.ECDSAWithKeyRecovery.Signature,
 		hashed: some DataProtocol,
 		options: K1.ECDSA.ValidationOptions = .default
 	) -> Bool {
 		do {
-			return try FFI.ECDSA.Recoverable.isValid(
+			return try FFI.ECDSAWithKeyRecovery.isValid(
 				signature: signature.wrapped,
 				publicKey: self.impl.wrapped,
 				message: [UInt8](hashed),
@@ -104,7 +104,7 @@ extension K1.ECDSA.Recoverable.PublicKey {
 	///   - options: Whether or not to consider malleable signatures valid.
 	/// - Returns: A Boolean value that’s true if the an Elliptic Curve Digital Signature Algorithm (ECDSA) recoverable signature is valid for the given digest.
 	public func isValidSignature(
-		_ signature: K1.ECDSA.Recoverable.Signature,
+		_ signature: K1.ECDSAWithKeyRecovery.Signature,
 		digest: some Digest,
 		options: K1.ECDSA.ValidationOptions = .default
 	) -> Bool {
@@ -126,7 +126,7 @@ extension K1.ECDSA.Recoverable.PublicKey {
 	///   - options: Whether or not to consider malleable signatures valid.
 	/// - Returns: A Boolean value that’s true if the an Elliptic Curve Digital Signature Algorithm (ECDSA) recoverable signature is valid for the given block of data.
 	public func isValidSignature(
-		_ signature: K1.ECDSA.Recoverable.Signature,
+		_ signature: K1.ECDSAWithKeyRecovery.Signature,
 		unhashed: some DataProtocol,
 		options: K1.ECDSA.ValidationOptions = .default
 	) -> Bool {

--- a/Sources/K1/K1/Validation/Validation.swift.gyb
+++ b/Sources/K1/K1/Validation/Validation.swift.gyb
@@ -10,7 +10,7 @@ import protocol CryptoKit.Digest
 	VARIANTS_OF_FEATURE = [
 		{
 			"scheme": "ECDSA",
-			"feature": "ECDSA.NonRecoverable",
+			"feature": "ECDSA",
 			"variant": "an Elliptic Curve Digital Signature Algorithm (ECDSA) non recoverable",
 			"docValidationParameterOptions": "\n///   - options: Whether or not to consider malleable signatures valid.",
 			"validationOptionsArg": ",\noptions: K1.ECDSA.ValidationOptions = .default",
@@ -18,7 +18,7 @@ import protocol CryptoKit.Digest
 		},
 		{
 			"scheme": "ECDSA",
-			"feature": "ECDSA.Recoverable",
+			"feature": "ECDSAWithKeyRecovery",
 			"variant": "an Elliptic Curve Digital Signature Algorithm (ECDSA) recoverable",
 			"docValidationParameterOptions": "\n///   - options: Whether or not to consider malleable signatures valid.",
 			"validationOptionsArg": ",\noptions: K1.ECDSA.ValidationOptions = .default",

--- a/Sources/K1/Support/FFI/API/ECDSA/FFI+ECDSA.swift
+++ b/Sources/K1/Support/FFI/API/ECDSA/FFI+ECDSA.swift
@@ -3,12 +3,8 @@ import secp256k1
 
 // MARK: - FFI.ECDSA
 extension FFI {
+	public enum ECDSAWithKeyRecovery {}
 	public enum ECDSA {}
-}
-
-extension FFI.ECDSA {
-	public enum Recoverable {}
-	public enum NonRecoverable {}
 }
 
 // MARK: - RawECDSASignature
@@ -31,8 +27,8 @@ protocol WrappedECDSASignature {
 }
 
 // MARK: ECDSA Shared
-extension FFI.ECDSA {
-	internal static func _sign<WrappedSignature>(
+extension FFI {
+	internal static func _ecdsa<WrappedSignature>(
 		message: [UInt8],
 		privateKey: FFI.PrivateKey.Wrapped,
 		options: K1.ECDSA.SigningOptions = .default

--- a/Sources/K1/Support/FFI/API/ECDSA/NonRecovery/ECDSA+NonRecovery+Wrapped.swift
+++ b/Sources/K1/Support/FFI/API/ECDSA/NonRecovery/ECDSA+NonRecovery+Wrapped.swift
@@ -1,8 +1,8 @@
 import Foundation
 import secp256k1
 
-// MARK: - FFI.ECDSA.NonRecoverable.Wrapped
-extension FFI.ECDSA.NonRecoverable {
+// MARK: - FFI.ECDSA.Wrapped
+extension FFI.ECDSA {
 	struct Wrapped: @unchecked Sendable, ContiguousBytes, WrappedECDSASignature {
 		typealias Raw = secp256k1_ecdsa_signature
 		let raw: Raw
@@ -13,14 +13,14 @@ extension FFI.ECDSA.NonRecoverable {
 }
 
 // MARK: Sign
-extension FFI.ECDSA.NonRecoverable.Wrapped {
+extension FFI.ECDSA.Wrapped {
 	static func sign() -> (OpaquePointer, UnsafeMutablePointer<Raw>, UnsafePointer<UInt8>, UnsafePointer<UInt8>, secp256k1_nonce_function?, UnsafeRawPointer?) -> Int32 {
 		secp256k1_ecdsa_sign
 	}
 }
 
 // MARK: ContiguousBytes
-extension FFI.ECDSA.NonRecoverable.Wrapped {
+extension FFI.ECDSA.Wrapped {
 	func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
 		var rawData = raw.data
 		return try Swift.withUnsafeBytes(of: &rawData) { pointer in

--- a/Sources/K1/Support/FFI/API/ECDSA/NonRecovery/FFI+ECDSA+NonRecovery.swift
+++ b/Sources/K1/Support/FFI/API/ECDSA/NonRecovery/FFI+ECDSA+NonRecovery.swift
@@ -2,7 +2,7 @@ import Foundation
 import secp256k1
 
 // MARK: Deserialize
-extension FFI.ECDSA.NonRecoverable {
+extension FFI.ECDSA {
 	static let byteCount = 2 * Curve.Field.byteCount
 
 	/// Compact aka `IEEE P1363` aka `R||S`.
@@ -24,7 +24,7 @@ extension FFI.ECDSA.NonRecoverable {
 }
 
 // MARK: Serialize
-extension FFI.ECDSA.NonRecoverable {
+extension FFI.ECDSA {
 	static func compact(_ wrapped: Wrapped) throws -> Data {
 		var out = [UInt8](repeating: 0, count: Self.byteCount)
 		var rawSignature = wrapped.raw
@@ -57,7 +57,7 @@ extension FFI.ECDSA.NonRecoverable {
 }
 
 // MARK: Recover
-extension FFI.ECDSA.NonRecoverable {
+extension FFI.ECDSA {
 	static func recoverPublicKey(
 		_ wrapped: Wrapped,
 		recoveryID: Int32,
@@ -66,7 +66,7 @@ extension FFI.ECDSA.NonRecoverable {
 		guard message.count == Curve.Field.byteCount else {
 			throw K1.Error.incorrectParameterSize
 		}
-		let nonRecoverableCompact = try FFI.ECDSA.NonRecoverable.compact(wrapped)
+		let nonRecoverableCompact = try FFI.ECDSA.compact(wrapped)
 		return try Self.recoverPublicKey(
 			nonRecoverableCompact: nonRecoverableCompact,
 			recoveryID: recoveryID,
@@ -106,9 +106,9 @@ extension FFI.ECDSA.NonRecoverable {
 }
 
 // MARK: Validate
-extension FFI.ECDSA.NonRecoverable {
+extension FFI.ECDSA {
 	static func isValid(
-		signature: FFI.ECDSA.NonRecoverable.Wrapped,
+		signature: FFI.ECDSA.Wrapped,
 		publicKey: FFI.PublicKey.Wrapped,
 		message: [UInt8],
 		options: K1.ECDSA.ValidationOptions = .default
@@ -153,14 +153,14 @@ extension FFI.ECDSA.NonRecoverable {
 }
 
 // MARK: Sign
-extension FFI.ECDSA.NonRecoverable {
+extension FFI.ECDSA {
 	/// Produces a **non recoverable** ECDSA signature from a hashed `message`
 	static func sign(
 		hashedMessage: [UInt8],
 		privateKey: FFI.PrivateKey.Wrapped,
 		options: K1.ECDSA.SigningOptions = .default
-	) throws -> FFI.ECDSA.NonRecoverable.Wrapped {
-		try FFI.ECDSA._sign(
+	) throws -> FFI.ECDSA.Wrapped {
+		try FFI._ecdsa(
 			message: hashedMessage,
 			privateKey: privateKey,
 			options: options

--- a/Sources/K1/Support/FFI/API/ECDSA/Recovery/ECDSA+Recovery+Wrapped.swift
+++ b/Sources/K1/Support/FFI/API/ECDSA/Recovery/ECDSA+Recovery+Wrapped.swift
@@ -1,8 +1,8 @@
 import Foundation
 import secp256k1
 
-// MARK: - FFI.ECDSA.Recoverable.Wrapped
-extension FFI.ECDSA.Recoverable {
+// MARK: - FFI.ECDSAWithKeyRecovery.Wrapped
+extension FFI.ECDSAWithKeyRecovery {
 	struct Wrapped: @unchecked Sendable, ContiguousBytes, WrappedECDSASignature {
 		typealias Raw = secp256k1_ecdsa_recoverable_signature
 		let raw: Raw
@@ -13,14 +13,14 @@ extension FFI.ECDSA.Recoverable {
 }
 
 // MARK: Sign
-extension FFI.ECDSA.Recoverable.Wrapped {
+extension FFI.ECDSAWithKeyRecovery.Wrapped {
 	static func sign() -> (OpaquePointer, UnsafeMutablePointer<Raw>, UnsafePointer<UInt8>, UnsafePointer<UInt8>, secp256k1_nonce_function?, UnsafeRawPointer?) -> Int32 {
 		secp256k1_ecdsa_sign_recoverable
 	}
 }
 
 // MARK: ContiguousBytes
-extension FFI.ECDSA.Recoverable.Wrapped {
+extension FFI.ECDSAWithKeyRecovery.Wrapped {
 	func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
 		var rawData = raw.data
 		return try Swift.withUnsafeBytes(of: &rawData) { pointer in

--- a/Sources/K1/Support/FFI/API/ECDSA/Recovery/FFI+ECDSA+Recovery.swift
+++ b/Sources/K1/Support/FFI/API/ECDSA/Recovery/FFI+ECDSA+Recovery.swift
@@ -2,8 +2,8 @@ import Foundation
 import secp256k1
 
 // MARK: Deserialize
-extension FFI.ECDSA.Recoverable {
-	static let byteCount = FFI.ECDSA.NonRecoverable.byteCount + 1
+extension FFI.ECDSAWithKeyRecovery {
+	static let byteCount = FFI.ECDSA.byteCount + 1
 
 	static func deserialize(
 		rawRepresentation: some DataProtocol
@@ -32,11 +32,11 @@ extension FFI.ECDSA.Recoverable {
 }
 
 // MARK: Serialize
-extension FFI.ECDSA.Recoverable {
+extension FFI.ECDSAWithKeyRecovery {
 	static func serializeCompact(
 		_ wrapped: Wrapped
 	) throws -> (rs: [UInt8], recoveryID: Int32) {
-		var rs = [UInt8](repeating: 0, count: FFI.ECDSA.NonRecoverable.byteCount)
+		var rs = [UInt8](repeating: 0, count: FFI.ECDSA.byteCount)
 		var recoveryID: Int32 = 0
 		var rawSignature = wrapped.raw
 		try FFI.call(
@@ -54,10 +54,10 @@ extension FFI.ECDSA.Recoverable {
 }
 
 // MARK: Convert
-extension FFI.ECDSA.Recoverable {
+extension FFI.ECDSAWithKeyRecovery {
 	static func nonRecoverable(
 		_ wrapped: Wrapped
-	) throws -> FFI.ECDSA.NonRecoverable.Wrapped {
+	) throws -> FFI.ECDSA.Wrapped {
 		var nonRecoverable = secp256k1_ecdsa_signature()
 		var recoverable = wrapped.raw
 
@@ -76,7 +76,7 @@ extension FFI.ECDSA.Recoverable {
 }
 
 // MARK: Recover
-extension FFI.ECDSA.Recoverable {
+extension FFI.ECDSAWithKeyRecovery {
 	static func recover(
 		_ wrapped: Wrapped,
 		message: [UInt8]
@@ -101,17 +101,17 @@ extension FFI.ECDSA.Recoverable {
 }
 
 // MARK: Validate
-extension FFI.ECDSA.Recoverable {
+extension FFI.ECDSAWithKeyRecovery {
 	static func isValid(
-		signature: FFI.ECDSA.Recoverable.Wrapped,
+		signature: FFI.ECDSAWithKeyRecovery.Wrapped,
 		publicKey: FFI.PublicKey.Wrapped,
 		message: [UInt8],
 		options: K1.ECDSA.ValidationOptions = .default
 	) throws -> Bool {
 		do {
 			let publicKeyNonRecoverable = FFI.PublicKey.Wrapped(raw: publicKey.raw)
-			let signatureNonRecoverable = try FFI.ECDSA.Recoverable.nonRecoverable(signature)
-			return try FFI.ECDSA.NonRecoverable.isValid(
+			let signatureNonRecoverable = try FFI.ECDSAWithKeyRecovery.nonRecoverable(signature)
+			return try FFI.ECDSA.isValid(
 				signature: signatureNonRecoverable,
 				publicKey: publicKeyNonRecoverable,
 				message: message,
@@ -124,14 +124,14 @@ extension FFI.ECDSA.Recoverable {
 }
 
 // MARK: Sign
-extension FFI.ECDSA.Recoverable {
+extension FFI.ECDSAWithKeyRecovery {
 	/// Produces a **recoverable** ECDSA signature from a hashed `message`
 	static func sign(
 		hashedMessage: [UInt8],
 		privateKey: K1._PrivateKeyImplementation.Wrapped,
 		options: K1.ECDSA.SigningOptions = .default
-	) throws -> FFI.ECDSA.Recoverable.Wrapped {
-		try FFI.ECDSA._sign(
+	) throws -> FFI.ECDSAWithKeyRecovery.Wrapped {
+		try FFI._ecdsa(
 			message: hashedMessage,
 			privateKey: privateKey,
 			options: options

--- a/Sources/K1/Support/FFI/Internals/FFI+Raw.swift
+++ b/Sources/K1/Support/FFI/Internals/FFI+Raw.swift
@@ -8,7 +8,7 @@ extension Raw {
 	static func recoverableSignature(
 		_ rawRepresentation: some DataProtocol
 	) throws -> secp256k1_ecdsa_recoverable_signature {
-		let expected = K1.ECDSA.Recoverable.Signature.Compact.byteCount
+		let expected = K1.ECDSAWithKeyRecovery.Signature.Compact.byteCount
 		guard
 			rawRepresentation.count == expected
 		else {

--- a/Tests/K1Tests/TestCases/APITest.swift
+++ b/Tests/K1Tests/TestCases/APITest.swift
@@ -1,0 +1,101 @@
+import CryptoKit
+import Foundation
+import K1 // not `@testable import`!!
+import XCTest
+
+final class APITest: XCTestCase {
+	func testECDSA() throws {
+		let privateKey: K1.ECDSA.PrivateKey = .init()
+		let publicKey: K1.ECDSA.PublicKey = privateKey.publicKey
+		let hashed = Data(SHA256.hash(data: Data("Hey Bob!".utf8)))
+		let signature = try privateKey.signature(for: hashed)
+		let isValid = publicKey.isValidSignature(signature, hashed: hashed)
+		XCTAssertTrue(isValid)
+
+		// Wrong public key
+		XCTAssertFalse(
+			type(of: privateKey).init().publicKey.isValidSignature(signature, hashed: hashed),
+			"When wrong public key is used to validate signature, validation should fail."
+		)
+
+		// Modify message
+		XCTAssertFalse(
+			publicKey.isValidSignature(signature, hashed: Data(hashed.reversed())),
+			"When the wrong message is used during validation of signature, validation should fail."
+		)
+
+		// Modify signature
+		try XCTAssertFalse(
+			publicKey.isValidSignature(.init(rawRepresentation: signature.rawRepresentation.reversed()), hashed: hashed),
+			"Tampered signatures should fail validation."
+		)
+	}
+
+	func testECDSAWithRecovery() throws {
+		let privateKey: K1.ECDSAWithKeyRecovery.PrivateKey = .init()
+		let publicKey: K1.ECDSAWithKeyRecovery.PublicKey = privateKey.publicKey
+		let hashed = Data(SHA256.hash(data: Data("Hey Bob!".utf8)))
+		let signature = try privateKey.signature(for: hashed)
+		let isValid = publicKey.isValidSignature(signature, hashed: hashed)
+		XCTAssertTrue(isValid)
+
+		// Wrong public key
+		XCTAssertFalse(
+			type(of: privateKey).init().publicKey.isValidSignature(signature, hashed: hashed),
+			"When wrong public key is used to validate signature, validation should fail."
+		)
+
+		// Modify message
+		XCTAssertFalse(
+			publicKey.isValidSignature(signature, hashed: Data(hashed.reversed())),
+			"When the wrong message is used during validation of signature, validation should fail."
+		)
+
+		// Modify signature
+		let modifiedSignature: K1.ECDSAWithKeyRecovery.Signature = try {
+			let compact = try signature.compact()
+			let rs = compact.compact
+			let v = compact.recoveryID
+			return try K1.ECDSAWithKeyRecovery.Signature(compact: .init(compact: .init(rs.reversed()), recoveryID: v))
+		}()
+		XCTAssertFalse(
+			publicKey.isValidSignature(modifiedSignature, hashed: hashed),
+			"Tampered signatures should fail validation."
+		)
+	}
+
+	func testSchnorr() throws {
+		let privateKey: K1.Schnorr.PrivateKey = .init()
+		let publicKey: K1.Schnorr.PublicKey = privateKey.publicKey
+		let hashed = Data(SHA256.hash(data: Data("Hey Bob!".utf8)))
+		let signature = try privateKey.signature(for: hashed)
+		let isValid = publicKey.isValidSignature(signature, hashed: hashed)
+		XCTAssertTrue(isValid)
+
+		// Wrong public key
+		XCTAssertFalse(
+			type(of: privateKey).init().publicKey.isValidSignature(signature, hashed: hashed),
+			"When wrong public key is used to validate signature, validation should fail."
+		)
+
+		// Modify message
+		XCTAssertFalse(
+			publicKey.isValidSignature(signature, hashed: Data(hashed.reversed())),
+			"When the wrong message is used during validation of signature, validation should fail."
+		)
+
+		// Modify signature
+		try XCTAssertFalse(
+			publicKey.isValidSignature(.init(rawRepresentation: signature.rawRepresentation.reversed()), hashed: hashed),
+			"Tampered signatures should fail validation."
+		)
+	}
+
+	func testECDH() throws {
+		let alice = K1.KeyAgreement.PrivateKey()
+		let bob = K1.KeyAgreement.PrivateKey()
+		let ab = try alice.sharedSecretFromKeyAgreement(with: bob.publicKey)
+		let ba = try bob.sharedSecretFromKeyAgreement(with: alice.publicKey)
+		XCTAssertEqual(ab, ba)
+	}
+}

--- a/Tests/K1Tests/TestCases/ECDSA/ECDSARecoverableSignatureRoundtripTests.swift
+++ b/Tests/K1Tests/TestCases/ECDSA/ECDSARecoverableSignatureRoundtripTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class ECDSARecoverableSignatureRoundtripTests: XCTestCase {
 	func testECDSARecoverable() throws {
-		let alice = K1.ECDSA.Recoverable.PrivateKey()
+		let alice = K1.ECDSAWithKeyRecovery.PrivateKey()
 		let message = "Send Bob 3 BTC".data(using: .utf8)!
 		let signature = try alice.signature(forUnhashed: message)
 		let isSignatureValid = alice.publicKey.isValidSignature(signature, unhashed: message)

--- a/Tests/K1Tests/TestCases/ECDSA/ECDSASignatureTests.swift
+++ b/Tests/K1Tests/TestCases/ECDSA/ECDSASignatureTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class ECDSASignatureTests: XCTestCase {
 	func testECDSADeterministic() throws {
-		let alice = K1.ECDSA.NonRecoverable.PrivateKey()
+		let alice = K1.ECDSA.PrivateKey()
 		let message = "Send Bob 3 BTC".data(using: .utf8)!
 
 		let signature = try alice.signature(forUnhashed: message)
@@ -15,11 +15,11 @@ final class ECDSASignatureTests: XCTestCase {
 
 	func testECDSARandom() throws {
 		continueAfterFailure = false
-		let alice = K1.ECDSA.NonRecoverable.PrivateKey()
+		let alice = K1.ECDSA.PrivateKey()
 		let message = "Send Bob 3 BTC".data(using: .utf8)!
 
 		let requestedNumberOfSignatures = 1000
-		var signatures = Set<K1.ECDSA.NonRecoverable.Signature>()
+		var signatures = Set<K1.ECDSA.Signature>()
 
 		for i in 0 ..< requestedNumberOfSignatures {
 			let signature = try alice.signature(

--- a/Tests/K1Tests/TestCases/ECDSA/ECDSASignatureTrezorTests.swift
+++ b/Tests/K1Tests/TestCases/ECDSA/ECDSASignatureTrezorTests.swift
@@ -32,8 +32,8 @@ private extension XCTestCase {
 	) throws -> ResultOfTestGroup {
 		var numberOfTestsRun = 0
 		for vector in group.tests {
-			let privateKey = try K1.ECDSA.NonRecoverable.PrivateKey(rawRepresentation: Data(hex: vector.privateKey))
-			let publicKey: K1.ECDSA.NonRecoverable.PublicKey = privateKey.publicKey
+			let privateKey = try K1.ECDSA.PrivateKey(rawRepresentation: Data(hex: vector.privateKey))
+			let publicKey: K1.ECDSA.PublicKey = privateKey.publicKey
 
 			let expectedSignature = try vector.expectedSignature()
 			let messageDigest = try vector.messageDigest()
@@ -50,7 +50,7 @@ private extension XCTestCase {
 			XCTAssertNotEqual(signatureRandom, expectedSignature)
 			XCTAssertTrue(publicKey.isValidSignature(signatureRandom, digest: messageDigest))
 
-			let privateKeyRecoverable = try K1.ECDSA.Recoverable.PrivateKey(rawRepresentation: privateKey.rawRepresentation)
+			let privateKeyRecoverable = try K1.ECDSAWithKeyRecovery.PrivateKey(rawRepresentation: privateKey.rawRepresentation)
 			let signatureRecoverableFromMessage = try privateKeyRecoverable.signature(for: messageDigest)
 			try XCTAssertEqual(signatureRecoverableFromMessage.nonRecoverable(), expectedSignature)
 			let recid = try signatureRecoverableFromMessage.compact().recoveryID
@@ -74,7 +74,7 @@ private extension XCTestCase {
 // MARK: - SignatureTrezorTestVector
 private struct SignatureTrezorTestVector: SignatureTestVector {
 	typealias MessageDigest = SHA256.Digest
-	typealias Signature = K1.ECDSA.NonRecoverable.Signature
+	typealias Signature = K1.ECDSA.Signature
 
 	let msg: String
 	let privateKey: String
@@ -95,7 +95,7 @@ private struct SignatureTrezorTestVector: SignatureTestVector {
 
 	func expectedSignature() throws -> Signature {
 		let derData = try Data(hex: expected.der)
-		let signature = try K1.ECDSA.NonRecoverable.Signature(derRepresentation: derData)
+		let signature = try K1.ECDSA.Signature(derRepresentation: derData)
 		XCTAssertEqual(signature.derRepresentation.hex, expected.der)
 		XCTAssertEqual(
 			signature.rawRepresentation.hex,
@@ -106,7 +106,7 @@ private struct SignatureTrezorTestVector: SignatureTestVector {
 		)
 
 		try XCTAssertEqual(
-			K1.ECDSA.NonRecoverable.Signature(rawRepresentation: Data(hex: expected.r + expected.s)),
+			K1.ECDSA.Signature(rawRepresentation: Data(hex: expected.r + expected.s)),
 			signature
 		)
 

--- a/Tests/K1Tests/TestCases/ECDSA/ECDSAWycheproofASNDEREncodedSignaturesTests.swift
+++ b/Tests/K1Tests/TestCases/ECDSA/ECDSAWycheproofASNDEREncodedSignaturesTests.swift
@@ -46,7 +46,7 @@ final class ECDSA_Wycheproof_ASN_DER_EncodedSignaturesTests: XCTestCase {
 // MARK: - SignatureWycheproofDERTestVector
 private struct SignatureWycheproofDERTestVector: WycheproofTestVector {
 	typealias MessageDigest = SHA256.Digest
-	typealias Signature = K1.ECDSA.NonRecoverable.Signature
+	typealias Signature = K1.ECDSA.Signature
 
 	let comment: String
 	let msg: String
@@ -62,7 +62,7 @@ private struct SignatureWycheproofDERTestVector: WycheproofTestVector {
 
 	func expectedSignature() throws -> Signature {
 		let derData = try Data(hex: sig)
-		let signature = try K1.ECDSA.NonRecoverable.Signature(derRepresentation: derData)
+		let signature = try K1.ECDSA.Signature(derRepresentation: derData)
 		if self.result == "valid" {
 			XCTAssertEqual(sig, signature.derRepresentation.hex)
 		}

--- a/Tests/K1Tests/TestCases/ECDSA/ECDSAWycheproofIEEEP1364RSEncodedSignaturesTests.swift
+++ b/Tests/K1Tests/TestCases/ECDSA/ECDSAWycheproofIEEEP1364RSEncodedSignaturesTests.swift
@@ -26,7 +26,7 @@ final class ECDSA_Wycheproof_IEEE_P1364_RS_EncodedSignaturesTests: XCTestCase {
 // MARK: - SignatureWycheproofP1364TestVector
 private struct SignatureWycheproofP1364TestVector: WycheproofTestVector {
 	typealias MessageDigest = SHA256.Digest
-	typealias Signature = K1.ECDSA.NonRecoverable.Signature
+	typealias Signature = K1.ECDSA.Signature
 
 	let comment: String
 	let msg: String

--- a/Tests/K1Tests/TestCases/Keys/PrivateKey/PrivateKeyEncodingTests.swift
+++ b/Tests/K1Tests/TestCases/Keys/PrivateKey/PrivateKeyEncodingTests.swift
@@ -7,39 +7,39 @@ final class PrivateKeyEncodingTests: XCTestCase {
 	func testRawRoundtrip() throws {
 		try doTest(
 			serialize: \.rawRepresentation,
-			deserialize: K1.ECDSA.NonRecoverable.PrivateKey.init(rawRepresentation:)
+			deserialize: K1.ECDSA.PrivateKey.init(rawRepresentation:)
 		)
 	}
 
 	func testx963Roundtrip() throws {
 		try doTest(
 			serialize: \.x963Representation,
-			deserialize: K1.ECDSA.NonRecoverable.PrivateKey.init(x963Representation:)
+			deserialize: K1.ECDSA.PrivateKey.init(x963Representation:)
 		)
 	}
 
 	func testDERRoundtrip() throws {
 		try doTest(
 			serialize: \.derRepresentation,
-			deserialize: K1.ECDSA.NonRecoverable.PrivateKey.init(derRepresentation:)
+			deserialize: K1.ECDSA.PrivateKey.init(derRepresentation:)
 		)
 	}
 
 	func testPEMRoundtrip() throws {
 		try doTest(
 			serialize: \.pemRepresentation,
-			deserialize: K1.ECDSA.NonRecoverable.PrivateKey.init(pemRepresentation:)
+			deserialize: K1.ECDSA.PrivateKey.init(pemRepresentation:)
 		)
 	}
 }
 
 private extension PrivateKeyEncodingTests {
 	func doTest<Enc: Equatable>(
-		serialize: KeyPath<K1.ECDSA.NonRecoverable.PrivateKey, Enc>,
-		deserialize: (Enc) throws -> K1.ECDSA.NonRecoverable.PrivateKey
+		serialize: KeyPath<K1.ECDSA.PrivateKey, Enc>,
+		deserialize: (Enc) throws -> K1.ECDSA.PrivateKey
 	) throws {
 		try doTestSerializationRoundtrip(
-			original: K1.ECDSA.NonRecoverable.PrivateKey(),
+			original: K1.ECDSA.PrivateKey(),
 			serialize: serialize,
 			deserialize: deserialize
 		)

--- a/Tests/K1Tests/TestCases/Keys/PrivateKey/PrivateKeyGenerationTests.swift
+++ b/Tests/K1Tests/TestCases/Keys/PrivateKey/PrivateKeyGenerationTests.swift
@@ -4,11 +4,11 @@ import XCTest
 
 final class PrivateKeyGenerationTests: XCTestCase {
 	func testGenerationWorks() throws {
-		XCTAssertNoThrow(K1.ECDSA.NonRecoverable.PrivateKey())
+		XCTAssertNoThrow(K1.ECDSA.PrivateKey())
 	}
 
 	func testRandom() throws {
 		// The probability of two keys being identical is approximately: 1/2^256
-		XCTAssertNotEqual(K1.ECDSA.NonRecoverable.PrivateKey(), K1.ECDSA.NonRecoverable.PrivateKey())
+		XCTAssertNotEqual(K1.ECDSA.PrivateKey(), K1.ECDSA.PrivateKey())
 	}
 }

--- a/Tests/K1Tests/TestCases/Keys/PrivateKey/PrivateKeyImportTests.swift
+++ b/Tests/K1Tests/TestCases/Keys/PrivateKey/PrivateKeyImportTests.swift
@@ -6,7 +6,7 @@ final class PrivateKeyImportTests: XCTestCase {
 	func testAssertImportingPrivateKeyWithTooFewBytesThrowsError() throws {
 		let raw = try Data(hex: "deadbeef")
 		try assert(
-			K1.ECDSA.NonRecoverable.PrivateKey(rawRepresentation: raw),
+			K1.ECDSA.PrivateKey(rawRepresentation: raw),
 			throws: K1.Error.incorrectKeySize
 		)
 	}
@@ -14,7 +14,7 @@ final class PrivateKeyImportTests: XCTestCase {
 	func testAssertImportingPrivateKeyWithTooManyBytesThrowsError() throws {
 		let raw = Data(repeating: 0xBA, count: 33)
 		try assert(
-			K1.ECDSA.NonRecoverable.PrivateKey(rawRepresentation: raw),
+			K1.ECDSA.PrivateKey(rawRepresentation: raw),
 			throws: K1.Error.incorrectKeySize
 		)
 	}
@@ -22,7 +22,7 @@ final class PrivateKeyImportTests: XCTestCase {
 	func testAssertImportingPrivateKeyZeroThrowsError() throws {
 		let raw = Data(repeating: 0x00, count: 32)
 		try assert(
-			K1.ECDSA.NonRecoverable.PrivateKey(rawRepresentation: raw),
+			K1.ECDSA.PrivateKey(rawRepresentation: raw),
 			throws: K1.Error.invalidKey
 		)
 	}
@@ -30,7 +30,7 @@ final class PrivateKeyImportTests: XCTestCase {
 	func testAssertImportingPrivateKeyCurveOrderThrowsError() throws {
 		let raw = try Data(hex: "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141")
 		try assert(
-			K1.ECDSA.NonRecoverable.PrivateKey(rawRepresentation: raw),
+			K1.ECDSA.PrivateKey(rawRepresentation: raw),
 			throws: K1.Error.underlyingLibsecp256k1Error(.publicKeyCreate)
 		)
 	}
@@ -38,17 +38,17 @@ final class PrivateKeyImportTests: XCTestCase {
 	func testAssertImportingPrivateKeyLargerThanCurveOrderThrowsError() throws {
 		let raw = Data(repeating: 0xFF, count: 32)
 		try assert(
-			K1.ECDSA.NonRecoverable.PrivateKey(rawRepresentation: raw),
+			K1.ECDSA.PrivateKey(rawRepresentation: raw),
 			throws: K1.Error.underlyingLibsecp256k1Error(.publicKeyCreate)
 		)
 	}
 
 	func testAssertPublicKeyOfImportedPrivateKey1() throws {
 		let privateKeyRaw = try Data(hex: "0000000000000000000000000000000000000000000000000000000000000001")
-		let privateKey = try K1.ECDSA.NonRecoverable.PrivateKey(rawRepresentation: privateKeyRaw)
+		let privateKey = try K1.ECDSA.PrivateKey(rawRepresentation: privateKeyRaw)
 		// Easily verified by: https://bitaddress.org/
 		// Pretty well known key pair
-		let expectedPublicKey = try K1.ECDSA.NonRecoverable.PublicKey(x963Representation: Data(hex: "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"))
+		let expectedPublicKey = try K1.ECDSA.PublicKey(x963Representation: Data(hex: "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"))
 		XCTAssertEqual(privateKey.publicKey, expectedPublicKey)
 	}
 }

--- a/Tests/K1Tests/TestCases/Keys/PublicKey/PublicKeyEncodingTests.generated.swift
+++ b/Tests/K1Tests/TestCases/Keys/PublicKey/PublicKeyEncodingTests.generated.swift
@@ -96,17 +96,17 @@ final class SchnorrPublicKeyEncodingDecodingRoundtripTests: XCTestCase {
 	}
 }
 
-extension K1.ECDSA.NonRecoverable.PublicKey {
+extension K1.ECDSA.PublicKey {
 	init() {
-		let pubKey = K1.ECDSA.NonRecoverable.PrivateKey().publicKey
+		let pubKey = K1.ECDSA.PrivateKey().publicKey
 		try! self.init(compressedRepresentation: pubKey.compressedRepresentation)
 	}
 }
 
-// MARK: - ECDSANonRecoverablePublicKeyEncodingDecodingRoundtripTests
-final class ECDSANonRecoverablePublicKeyEncodingDecodingRoundtripTests: XCTestCase {
+// MARK: - ECDSAPublicKeyEncodingDecodingRoundtripTests
+final class ECDSAPublicKeyEncodingDecodingRoundtripTests: XCTestCase {
 	func test_pubkey_raw_is_x963_minus_prefix() throws {
-		let privateKey = K1.ECDSA.NonRecoverable.PrivateKey()
+		let privateKey = K1.ECDSA.PrivateKey()
 		let publicKey = privateKey.publicKey
 
 		XCTAssertEqual(publicKey.rawRepresentation.hex, Data(publicKey.x963Representation.dropFirst()).hex)
@@ -114,56 +114,56 @@ final class ECDSANonRecoverablePublicKeyEncodingDecodingRoundtripTests: XCTestCa
 
 	func testRawRoundtrip() throws {
 		try doTest(
-			original: K1.ECDSA.NonRecoverable.PublicKey(),
+			original: K1.ECDSA.PublicKey(),
 			serialize: \.rawRepresentation,
-			deserialize: K1.ECDSA.NonRecoverable.PublicKey.init(rawRepresentation:)
+			deserialize: K1.ECDSA.PublicKey.init(rawRepresentation:)
 		)
 	}
 
 	func testCompressedRoundtrip() throws {
 		try doTest(
-			original: K1.ECDSA.NonRecoverable.PublicKey(),
+			original: K1.ECDSA.PublicKey(),
 			serialize: \.compressedRepresentation,
-			deserialize: K1.ECDSA.NonRecoverable.PublicKey.init(compressedRepresentation:)
+			deserialize: K1.ECDSA.PublicKey.init(compressedRepresentation:)
 		)
 	}
 
 	func testx963Roundtrip() throws {
 		try doTest(
-			original: K1.ECDSA.NonRecoverable.PublicKey(),
+			original: K1.ECDSA.PublicKey(),
 			serialize: \.x963Representation,
-			deserialize: K1.ECDSA.NonRecoverable.PublicKey.init(x963Representation:)
+			deserialize: K1.ECDSA.PublicKey.init(x963Representation:)
 		)
 	}
 
 	func testDERRoundtrip() throws {
 		try doTest(
-			original: K1.ECDSA.NonRecoverable.PublicKey(),
+			original: K1.ECDSA.PublicKey(),
 			serialize: \.derRepresentation,
-			deserialize: K1.ECDSA.NonRecoverable.PublicKey.init(derRepresentation:)
+			deserialize: K1.ECDSA.PublicKey.init(derRepresentation:)
 		)
 	}
 
 	func testPEMRoundtrip() throws {
 		try doTest(
-			original: K1.ECDSA.NonRecoverable.PublicKey(),
+			original: K1.ECDSA.PublicKey(),
 			serialize: \.pemRepresentation,
-			deserialize: K1.ECDSA.NonRecoverable.PublicKey.init(pemRepresentation:)
+			deserialize: K1.ECDSA.PublicKey.init(pemRepresentation:)
 		)
 	}
 }
 
-extension K1.ECDSA.Recoverable.PublicKey {
+extension K1.ECDSAWithKeyRecovery.PublicKey {
 	init() {
-		let pubKey = K1.ECDSA.Recoverable.PrivateKey().publicKey
+		let pubKey = K1.ECDSAWithKeyRecovery.PrivateKey().publicKey
 		try! self.init(compressedRepresentation: pubKey.compressedRepresentation)
 	}
 }
 
-// MARK: - ECDSARecoverablePublicKeyEncodingDecodingRoundtripTests
-final class ECDSARecoverablePublicKeyEncodingDecodingRoundtripTests: XCTestCase {
+// MARK: - ECDSAWithKeyRecoveryPublicKeyEncodingDecodingRoundtripTests
+final class ECDSAWithKeyRecoveryPublicKeyEncodingDecodingRoundtripTests: XCTestCase {
 	func test_pubkey_raw_is_x963_minus_prefix() throws {
-		let privateKey = K1.ECDSA.Recoverable.PrivateKey()
+		let privateKey = K1.ECDSAWithKeyRecovery.PrivateKey()
 		let publicKey = privateKey.publicKey
 
 		XCTAssertEqual(publicKey.rawRepresentation.hex, Data(publicKey.x963Representation.dropFirst()).hex)
@@ -171,41 +171,41 @@ final class ECDSARecoverablePublicKeyEncodingDecodingRoundtripTests: XCTestCase 
 
 	func testRawRoundtrip() throws {
 		try doTest(
-			original: K1.ECDSA.Recoverable.PublicKey(),
+			original: K1.ECDSAWithKeyRecovery.PublicKey(),
 			serialize: \.rawRepresentation,
-			deserialize: K1.ECDSA.Recoverable.PublicKey.init(rawRepresentation:)
+			deserialize: K1.ECDSAWithKeyRecovery.PublicKey.init(rawRepresentation:)
 		)
 	}
 
 	func testCompressedRoundtrip() throws {
 		try doTest(
-			original: K1.ECDSA.Recoverable.PublicKey(),
+			original: K1.ECDSAWithKeyRecovery.PublicKey(),
 			serialize: \.compressedRepresentation,
-			deserialize: K1.ECDSA.Recoverable.PublicKey.init(compressedRepresentation:)
+			deserialize: K1.ECDSAWithKeyRecovery.PublicKey.init(compressedRepresentation:)
 		)
 	}
 
 	func testx963Roundtrip() throws {
 		try doTest(
-			original: K1.ECDSA.Recoverable.PublicKey(),
+			original: K1.ECDSAWithKeyRecovery.PublicKey(),
 			serialize: \.x963Representation,
-			deserialize: K1.ECDSA.Recoverable.PublicKey.init(x963Representation:)
+			deserialize: K1.ECDSAWithKeyRecovery.PublicKey.init(x963Representation:)
 		)
 	}
 
 	func testDERRoundtrip() throws {
 		try doTest(
-			original: K1.ECDSA.Recoverable.PublicKey(),
+			original: K1.ECDSAWithKeyRecovery.PublicKey(),
 			serialize: \.derRepresentation,
-			deserialize: K1.ECDSA.Recoverable.PublicKey.init(derRepresentation:)
+			deserialize: K1.ECDSAWithKeyRecovery.PublicKey.init(derRepresentation:)
 		)
 	}
 
 	func testPEMRoundtrip() throws {
 		try doTest(
-			original: K1.ECDSA.Recoverable.PublicKey(),
+			original: K1.ECDSAWithKeyRecovery.PublicKey(),
 			serialize: \.pemRepresentation,
-			deserialize: K1.ECDSA.Recoverable.PublicKey.init(pemRepresentation:)
+			deserialize: K1.ECDSAWithKeyRecovery.PublicKey.init(pemRepresentation:)
 		)
 	}
 }

--- a/Tests/K1Tests/TestCases/Keys/PublicKey/PublicKeyEncodingTests.swift.gyb
+++ b/Tests/K1Tests/TestCases/Keys/PublicKey/PublicKeyEncodingTests.swift.gyb
@@ -42,7 +42,7 @@ public func doTestSerializationRoundtrip<T, Enc>(
 
 
 %{
-	FEATURES = ["Schnorr", "ECDSA.NonRecoverable", "ECDSA.Recoverable", "KeyAgreement"]
+	FEATURES = ["Schnorr", "ECDSA", "ECDSAWithKeyRecovery", "KeyAgreement"]
 }%
 
 % for FEATURE in FEATURES:

--- a/Tests/K1Tests/TestCases/Keys/PublicKey/PublicKeyImportTests.swift
+++ b/Tests/K1Tests/TestCases/Keys/PublicKey/PublicKeyImportTests.swift
@@ -6,7 +6,7 @@ final class PublicKeyImportTests: XCTestCase {
 	func testAssertImportingPublicKeyWithTooFewBytesThrowsError() throws {
 		let raw = try Data(hex: "deadbeef")
 		try assert(
-			K1.ECDSA.NonRecoverable.PublicKey(x963Representation: raw),
+			K1.ECDSA.PublicKey(x963Representation: raw),
 			throws: K1.Error.incorrectKeySize
 		)
 	}
@@ -14,7 +14,7 @@ final class PublicKeyImportTests: XCTestCase {
 	func testAssertImportingPublicKeyWithTooManyBytesThrowsError() throws {
 		let raw = Data(repeating: 0xDE, count: 66)
 		try assert(
-			K1.ECDSA.NonRecoverable.PublicKey(x963Representation: raw),
+			K1.ECDSA.PublicKey(x963Representation: raw),
 			throws: K1.Error.incorrectKeySize
 		)
 	}
@@ -22,7 +22,7 @@ final class PublicKeyImportTests: XCTestCase {
 	func testAssertImportingInvalidUncompressedPublicKeyThrowsError() throws {
 		let raw = Data(repeating: 0x04, count: 65)
 		try assert(
-			K1.ECDSA.NonRecoverable.PublicKey(x963Representation: raw),
+			K1.ECDSA.PublicKey(x963Representation: raw),
 			throws: K1.Error.underlyingLibsecp256k1Error(.publicKeyParse)
 		)
 	}
@@ -30,21 +30,21 @@ final class PublicKeyImportTests: XCTestCase {
 	func testAssertImportingInvalidCompressedPublicKeyThrowsError() throws {
 		let raw = Data(repeating: 0x03, count: 33)
 		try assert(
-			K1.ECDSA.NonRecoverable.PublicKey(compressedRepresentation: raw),
+			K1.ECDSA.PublicKey(compressedRepresentation: raw),
 			throws: K1.Error.underlyingLibsecp256k1Error(.publicKeyParse)
 		)
 	}
 
 	func testAssertImportValidPublicKeyWorks() throws {
 		let raw = Data(repeating: 0x02, count: 33)
-		let publicKey = try K1.ECDSA.NonRecoverable.PublicKey(compressedRepresentation: raw)
+		let publicKey = try K1.ECDSA.PublicKey(compressedRepresentation: raw)
 		XCTAssertEqual(publicKey.compressedRepresentation.hex, "020202020202020202020202020202020202020202020202020202020202020202")
 		XCTAssertEqual(publicKey.x963Representation.hex, "040202020202020202020202020202020202020202020202020202020202020202415456f0fc01d66476251cab4525d9db70bfec652b2d8130608675674cde64b2")
 	}
 
 	func test_compress_pubkey() throws {
 		let raw = Data(repeating: 0x02, count: 33)
-		let publicKey = try K1.ECDSA.NonRecoverable.PublicKey(compressedRepresentation: raw)
+		let publicKey = try K1.ECDSA.PublicKey(compressedRepresentation: raw)
 		XCTAssertEqual(publicKey.compressedRepresentation.hex, "020202020202020202020202020202020202020202020202020202020202020202")
 		XCTAssertEqual(publicKey.x963Representation.hex, "040202020202020202020202020202020202020202020202020202020202020202415456f0fc01d66476251cab4525d9db70bfec652b2d8130608675674cde64b2")
 	}
@@ -57,7 +57,7 @@ final class PublicKeyImportTests: XCTestCase {
 		let raw = try Data(hex: "040000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2e")
 
 		try assert(
-			K1.ECDSA.NonRecoverable.PublicKey(x963Representation: raw),
+			K1.ECDSA.PublicKey(x963Representation: raw),
 			throws: K1.Error.underlyingLibsecp256k1Error(.publicKeyParse)
 		)
 	}

--- a/Tests/K1Tests/TestCases/Performance/PerformanceTests.swift
+++ b/Tests/K1Tests/TestCases/Performance/PerformanceTests.swift
@@ -20,15 +20,15 @@ final class PerformanceTests: XCTestCase {
 						schnorrPublicKey
 					)
 
-					let ecdsaPrivateKey = K1.ECDSA.Recoverable.PrivateKey()
+					let ecdsaPrivateKey = K1.ECDSAWithKeyRecovery.PrivateKey()
 					let ecdsaPublicKey = ecdsaPrivateKey.publicKey
 
 					try XCTAssertEqual(
-						K1.ECDSA.Recoverable.PublicKey(compressedRepresentation: ecdsaPublicKey.compressedRepresentation),
+						K1.ECDSAWithKeyRecovery.PublicKey(compressedRepresentation: ecdsaPublicKey.compressedRepresentation),
 						ecdsaPublicKey
 					)
 					try XCTAssertEqual(
-						K1.ECDSA.Recoverable.PublicKey(x963Representation: ecdsaPublicKey.x963Representation),
+						K1.ECDSAWithKeyRecovery.PublicKey(x963Representation: ecdsaPublicKey.x963Representation),
 						ecdsaPublicKey
 					)
 
@@ -40,15 +40,15 @@ final class PerformanceTests: XCTestCase {
 						)
 					)
 					try XCTAssertEqual(
-						K1.ECDSA.Recoverable.Signature(compact: ecdsa.compact()),
+						K1.ECDSAWithKeyRecovery.Signature(compact: ecdsa.compact()),
 						ecdsa
 					)
 					try XCTAssertEqual(
-						K1.ECDSA.NonRecoverable.Signature(rawRepresentation: ecdsa.nonRecoverable().rawRepresentation),
+						K1.ECDSA.Signature(rawRepresentation: ecdsa.nonRecoverable().rawRepresentation),
 						ecdsa.nonRecoverable()
 					)
 					try XCTAssertEqual(
-						K1.ECDSA.NonRecoverable.Signature(derRepresentation: ecdsa.nonRecoverable().derRepresentation),
+						K1.ECDSA.Signature(derRepresentation: ecdsa.nonRecoverable().derRepresentation),
 						ecdsa.nonRecoverable()
 					)
 

--- a/Tests/K1Tests/TestCases/PublicKeyRecovery/ECDASignaturePublicKeyRecoveryTests.swift
+++ b/Tests/K1Tests/TestCases/PublicKeyRecovery/ECDASignaturePublicKeyRecoveryTests.swift
@@ -23,7 +23,7 @@ final class ECDASignaturePublicKeyRecoveryTests: XCTestCase {
 	func test_conversionRoundtrips() throws {
 		let recoverySignatureHex = "acf9e195e094f2f40eb619b9878817ff951b9b11fac37cf0d7290098bbefb574f8606281a2231a3fc781045f2ea4df086936263bbfa8d15ca17fe70e0c3d6e5601"
 		let recoverableSigRaw = try Data(hex: recoverySignatureHex)
-		let recoverableSig = try K1.ECDSA.Recoverable.Signature(internalRepresentation: recoverableSigRaw)
+		let recoverableSig = try K1.ECDSAWithKeyRecovery.Signature(internalRepresentation: recoverableSigRaw)
 		XCTAssertEqual(recoverableSig.internalRepresentation.hex, recoverySignatureHex)
 
 		let compactRSV = "74b5efbb980029d7f07cc3fa119b1b95ff178887b919b60ef4f294e095e1f9ac566e3d0c0ee77fa15cd1a8bf3b26366908dfa42e5f0481c73f1a23a2816260f801"
@@ -33,28 +33,28 @@ final class ECDASignaturePublicKeyRecoveryTests: XCTestCase {
 
 		try XCTAssertEqual(
 			recoverableSig.internalRepresentation.hex,
-			K1.ECDSA.Recoverable.Signature(compact: .init(rawRepresentation: Data(hex: compactVRS), format: .vrs)).internalRepresentation.hex
+			K1.ECDSAWithKeyRecovery.Signature(compact: .init(rawRepresentation: Data(hex: compactVRS), format: .vrs)).internalRepresentation.hex
 		)
 
 		let compactRecoverableSig = try recoverableSig.compact()
 
 		let compactRecoverableSigRSHex = "74b5efbb980029d7f07cc3fa119b1b95ff178887b919b60ef4f294e095e1f9ac566e3d0c0ee77fa15cd1a8bf3b26366908dfa42e5f0481c73f1a23a2816260f8"
-		let recid = try K1.ECDSA.Recoverable.Signature.RecoveryID(recid: 1)
+		let recid = try K1.ECDSAWithKeyRecovery.Signature.RecoveryID(recid: 1)
 		XCTAssertEqual(compactRecoverableSig.compact.hex, compactRecoverableSigRSHex)
 		XCTAssertEqual(compactRecoverableSig.recoveryID, recid)
 
 		let compactRecoverableSigRS = try Data(hex: compactRecoverableSigRSHex)
-		try XCTAssertEqual(K1.ECDSA.Recoverable.Signature(compact: compactRecoverableSigRS, recoveryID: recid), K1.ECDSA.Recoverable.Signature(compact: compactRecoverableSig))
-		try XCTAssertEqual(K1.ECDSA.Recoverable.Signature.Compact(compact: compactRecoverableSigRS, recoveryID: recid), compactRecoverableSig)
+		try XCTAssertEqual(K1.ECDSAWithKeyRecovery.Signature(compact: compactRecoverableSigRS, recoveryID: recid), K1.ECDSAWithKeyRecovery.Signature(compact: compactRecoverableSig))
+		try XCTAssertEqual(K1.ECDSAWithKeyRecovery.Signature.Compact(compact: compactRecoverableSigRS, recoveryID: recid), compactRecoverableSig)
 
-		let nonRecoverable = try K1.ECDSA.NonRecoverable.Signature(rawRepresentation: compactRecoverableSig.compact)
+		let nonRecoverable = try K1.ECDSA.Signature(rawRepresentation: compactRecoverableSig.compact)
 
 		try XCTAssertEqual(nonRecoverable, recoverableSig.nonRecoverable())
 		let nonRecovDer = nonRecoverable.derRepresentation
 		let nonRecoveryDERHex = "3044022074b5efbb980029d7f07cc3fa119b1b95ff178887b919b60ef4f294e095e1f9ac0220566e3d0c0ee77fa15cd1a8bf3b26366908dfa42e5f0481c73f1a23a2816260f8"
 		XCTAssertEqual(nonRecovDer.hex, nonRecoveryDERHex)
 
-		try XCTAssertEqual(K1.ECDSA.NonRecoverable.Signature(derRepresentation: Data(hex: nonRecoveryDERHex)), nonRecoverable)
+		try XCTAssertEqual(K1.ECDSA.Signature(derRepresentation: Data(hex: nonRecoveryDERHex)), nonRecoverable)
 	}
 }
 
@@ -67,7 +67,7 @@ private extension ECDASignaturePublicKeyRecoveryTests {
 		var numberOfTestsRun = 0
 		for vector in group.tests {
 			let publicKeyUncompressed = try [UInt8](hex: vector.publicKeyUncompressed)
-			let expectedPublicKey = try K1.ECDSA.Recoverable.PublicKey(x963Representation: publicKeyUncompressed)
+			let expectedPublicKey = try K1.ECDSAWithKeyRecovery.PublicKey(x963Representation: publicKeyUncompressed)
 
 			XCTAssertEqual(
 				try Data(hex: vector.publicKeyCompressed),
@@ -111,13 +111,13 @@ struct IncorrectByteCount: Swift.Error {}
 
 // MARK: - RecoveryTestVector
 struct RecoveryTestVector: Decodable, Equatable {
-	let recoveryID: K1.ECDSA.Recoverable.Signature.RecoveryID
+	let recoveryID: K1.ECDSAWithKeyRecovery.Signature.RecoveryID
 	let message: String
 	let hashMessage: String
 	private let signature: String
 
-	func recoverableSignature() throws -> K1.ECDSA.Recoverable.Signature {
-		try K1.ECDSA.Recoverable.Signature(
+	func recoverableSignature() throws -> K1.ECDSAWithKeyRecovery.Signature {
+		try K1.ECDSAWithKeyRecovery.Signature(
 			internalRepresentation: Data(hex: signature)
 		)
 	}
@@ -126,8 +126,8 @@ struct RecoveryTestVector: Decodable, Equatable {
 	let publicKeyCompressed: String
 }
 
-// MARK: - K1.ECDSA.Recoverable.Signature.RecoveryID + ExpressibleByIntegerLiteral
-extension K1.ECDSA.Recoverable.Signature.RecoveryID: ExpressibleByIntegerLiteral {
+// MARK: - K1.ECDSAWithKeyRecovery.Signature.RecoveryID + ExpressibleByIntegerLiteral
+extension K1.ECDSAWithKeyRecovery.Signature.RecoveryID: ExpressibleByIntegerLiteral {
 	public init(integerLiteral value: UInt8) {
 		self.init(rawValue: value)!
 	}

--- a/Tests/K1Tests/Util/ECSignature.swift
+++ b/Tests/K1Tests/Util/ECSignature.swift
@@ -4,8 +4,8 @@ import K1
 // MARK: - ECSignature
 public protocol ECSignature {}
 
-// MARK: - K1.ECDSA.NonRecoverable.Signature + ECSignature
-extension K1.ECDSA.NonRecoverable.Signature: ECSignature {}
+// MARK: - K1.ECDSA.Signature + ECSignature
+extension K1.ECDSA.Signature: ECSignature {}
 
-// MARK: - K1.ECDSA.Recoverable.Signature + ECSignature
-extension K1.ECDSA.Recoverable.Signature: ECSignature {}
+// MARK: - K1.ECDSAWithKeyRecovery.Signature + ECSignature
+extension K1.ECDSAWithKeyRecovery.Signature: ECSignature {}

--- a/Tests/K1Tests/Util/Wycheproof.swift
+++ b/Tests/K1Tests/Util/Wycheproof.swift
@@ -88,13 +88,13 @@ extension XCTestCase {
 			throw ECDSASignatureTestError(description: errorMessage)
 		}
 		let keyBytes = try Array(hex: group.key.uncompressed)
-		let key = try K1.ECDSA.NonRecoverable.PublicKey(x963Representation: keyBytes)
+		let key = try K1.ECDSA.PublicKey(x963Representation: keyBytes)
 
-		let keyFromDER = try K1.ECDSA.NonRecoverable.PublicKey(derRepresentation: Data(hex: group.keyDer))
+		let keyFromDER = try K1.ECDSA.PublicKey(derRepresentation: Data(hex: group.keyDer))
 		XCTAssertEqual(key.derRepresentation.hex, group.keyDer)
 		XCTAssertEqual(keyFromDER, key)
 
-		let keyFromPEM = try K1.ECDSA.NonRecoverable.PublicKey(pemRepresentation: group.keyPem)
+		let keyFromPEM = try K1.ECDSA.PublicKey(pemRepresentation: group.keyPem)
 		XCTAssertEqual(key.pemRepresentation, group.keyPem)
 		XCTAssertEqual(keyFromPEM, key)
 
@@ -120,7 +120,7 @@ extension XCTestCase {
 		let pubKeyXOnly = try ensure32Bytes(keyCompactXRaw)
 		let pubKeyYOnly = try ensure32Bytes(keyCompactYRaw)
 
-		let pubKeyFromRaw = try K1.ECDSA.NonRecoverable.PublicKey(rawRepresentation: pubKeyXOnly + pubKeyYOnly)
+		let pubKeyFromRaw = try K1.ECDSA.PublicKey(rawRepresentation: pubKeyXOnly + pubKeyYOnly)
 		XCTAssertEqual(pubKeyFromRaw, key)
 
 		var numberOfTestsRun = 0
@@ -211,7 +211,7 @@ protocol SignatureTestVector: Codable {
 }
 
 // MARK: - WycheproofTestVector
-protocol WycheproofTestVector: SignatureTestVector where Signature == K1.ECDSA.NonRecoverable.Signature {
+protocol WycheproofTestVector: SignatureTestVector where Signature == K1.ECDSA.Signature {
 	var flags: [String] { get }
 	var tcId: Int { get }
 	var result: String { get }


### PR DESCRIPTION
This PR changes two two namespaces:
`K1.ECDSA.Recoverable` and `K1.ECDSA.NonRecoverable` into `K1.ECDSAWithKeyRecovery` and just `K1.ECDSA` respectively. 

The rationale is:
* This flattens the otherwise nested structure `ECDSA` (which was the namespace for `Recoverable` and `NonRecoverable` which was kind of asymmetric w.r.t. `K1.Schnorr`.
* _Assumption_: Most user are probably not in need of ECDSA signatures that do offer recoverability of public key, therefor being able to use the much shorter namespace `K1.ECDSA` instead of `K1.ECDSA.NonRecoverable` is preferred. 

Drawback:
Both ECDSA variants have two structs with options used for signing and validation, named both before this PR and after this PR (i.e. unchanged) `K1.ECDSA.SigningOptions` and `K1.ECDSA.ValidationOptions`, and it before this PR it was hiearcally correct that these structs was defined in the _shared namespace_ `ECDSA`. If this PR were to be merged it is less elegant that it looks like these structs belong to the non recoverable ECDSA variant, since it is used by both. However this is mostly a detail.

I'm torn between what the best API... Unfortunately swift-crypto has not solved this particular problem of two variant for the same signature scheme, so I can't look for answer there (which I've otherwise done a lot when designing the API of this library). 


Summary of API:

Given:
```swift
let hashed = Data(SHA256.hash(data: Data("Hey Bob!".utf8)))
```

## ECDSA
```swift
let privateKey: K1.ECDSA.PrivateKey = .init()
let publicKey: K1.ECDSA.PublicKey = privateKey.publicKey
let signature = try privateKey.signature(for: hashed)
publicKey.isValidSignature(signature, hashed: hashed) // true
```

## ECDSA With Recovery
```swift
let privateKey: K1.ECDSAWithKeyRecovery.PrivateKey = .init()
let publicKey: K1.ECDSAWithKeyRecovery.PublicKey = privateKey.publicKey
let signature = try privateKey.signature(for: hashed)
publicKey.isValidSignature(signature, hashed: hashed) // true
```

## Schnorr (unchanged)
```swift
let privateKey: K1.Schnorr.PrivateKey = .init()
let publicKey: K1.Schnorr.PublicKey = privateKey.publicKey
let signature = try privateKey.signature(for: hashed)
publicKey.isValidSignature(signature, hashed: hashed) // true
```