### PR TITLE
Revert usage of unsafeFlags to suppress C warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,11 +65,6 @@ let package = Package(
 				.define("ENABLE_MODULE_RECOVERY"),
 				.define("ENABLE_MODULE_SCHNORRSIG"),
 				.define("ENABLE_MODULE_EXTRAKEYS"),
-
-				// Suppress build warnings
-				.unsafeFlags(
-					["-Wno-shorten-64-to-32"]
-				),
 			]
 		),
 		.target(

--- a/Sources/K1/K1/ECDSA/ECDSASignatureRecoverable.swift
+++ b/Sources/K1/K1/ECDSA/ECDSASignatureRecoverable.swift
@@ -135,7 +135,8 @@ extension K1.ECDSAWithKeyRecovery.Signature.Compact {
 		/// This is the default value of this library.
 		case rsv
 
-		/// We use `R || S || V` as default values since `libsecp256k1` v0.3.0 uses it as its representation.
+		/// We use `R || S || V` as default values since `libsecp256k1` v0.7.1
+		/// uses it as its internal representation.
 		public static let `default`: Self = .rsv
 
 		/// `V || R || S`.

--- a/Sources/K1/Support/ThirdyParty/swift-crypto/ASN1/ASN1.swift
+++ b/Sources/K1/Support/ThirdyParty/swift-crypto/ASN1/ASN1.swift
@@ -201,7 +201,7 @@ extension ASN1 {
 
         // We expect a single child.
         guard case .constructed(let nodes) = node.content else {
-            // This error is an parser error: the tag above is always constructed.
+            // This error is an internal parser error: the tag above is always constructed.
             preconditionFailure("Explicit tags are always constructed")
         }
 


### PR DESCRIPTION
Revert usage of unsafe flags since it prevents developers from using K1.

```sh
error: 'mypkg': the target 'secp256k1' in product 'K1' contains unsafe build flags
```

Also revert accidental incorrect removal of `"internal"`.